### PR TITLE
feat: 窗口显示兼容 win 鼠标跟随

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -987,21 +987,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "device_query"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bafa241a89a5edccff5057d0b85fbc083a781bd03d766c11a688331604980985"
-dependencies = [
- "lazy_static",
- "macos-accessibility-client",
- "pkg-config",
- "readkey",
- "readmouse",
- "windows 0.48.0",
- "x11",
-]
-
-[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1092,7 +1077,7 @@ name = "eco-copy"
 version = "0.0.0"
 dependencies = [
  "clipboard-rs",
- "device_query",
+ "mouse_position",
  "serde",
  "serde_json",
  "tauri",
@@ -2415,16 +2400,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
 
 [[package]]
-name = "macos-accessibility-client"
-version = "0.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edf7710fbff50c24124331760978fb9086d6de6288dcdb38b25a97f8b1bdebbb"
-dependencies = [
- "core-foundation",
- "core-foundation-sys",
-]
-
-[[package]]
 name = "malloc_buf"
 version = "0.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2531,6 +2506,17 @@ dependencies = [
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "mouse_position"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824feb0675ad2ffda7b1da534f394c5779fb39d123b5f376a221d50fad54b3c2"
+dependencies = [
+ "core-graphics 0.22.3",
+ "winapi",
+ "x11-dl",
 ]
 
 [[package]]
@@ -3405,18 +3391,6 @@ dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
 ]
-
-[[package]]
-name = "readkey"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7677f98ca49bc9bb26e04c8abf80ba579e2cb98e8a384a0ff8128ad70670d249"
-
-[[package]]
-name = "readmouse"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be105c72a1e6a5a1198acee3d5b506a15676b74a02ecd78060042a447f408d94"
 
 [[package]]
 name = "redox_syscall"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -21,7 +21,7 @@ tauri-plugin-sql = { git = "https://github.com/tauri-apps/plugins-workspace", br
 window-shadows = "0.2.2"
 clipboard-rs = "0.1.7"
 tauri-plugin-context-menu = { git = "https://github.com/c2r0b/tauri-plugin-context-menu", branch = "main" }
-device_query = "2.1.0"
+mouse_position = "0.1.4"
 
 [features]
 # This feature is used for production builds or when a dev server is not specified, DO NOT REMOVE!!

--- a/src-tauri/src/plugins/mouse.rs
+++ b/src-tauri/src/plugins/mouse.rs
@@ -1,17 +1,18 @@
-use device_query::{DeviceQuery, DeviceState};
+use mouse_position::mouse_position::Mouse;
+
 use tauri::{
     command, generate_handler,
     plugin::{Builder, TauriPlugin},
-    Result, Wry,
+    Result, Wry,Error
 };
 
 #[command]
 async fn get_mouse_coords() -> Result<(i32, i32)> {
-    let device_state = DeviceState::new();
-
-    let mouse = device_state.get_mouse();
-
-    Ok(mouse.coords)
+  let position = Mouse::get_mouse_position();
+    match position {
+        Mouse::Position { x, y } => {Ok((x,y))},
+        Mouse::Error => Err(Error::InvokeKey),
+   }
 }
 
 pub fn init() -> TauriPlugin<Wry> {

--- a/src/pages/Clipboard/History/index.tsx
+++ b/src/pages/Clipboard/History/index.tsx
@@ -112,8 +112,10 @@ const ClipboardHistory = () => {
 					size: { width: screenWidth, height: screenHeight },
 				} = monitor;
 
-				x = Math.min(x * scaleFactor, screenWidth - width);
-				y = Math.min(y * scaleFactor, screenHeight - height);
+				const factor = (await isWin()) ? 1 : scaleFactor;
+
+				x = Math.min(x * factor, screenWidth - width);
+				y = Math.min(y * factor, screenHeight - height);
 
 				appWindow.setPosition(new PhysicalPosition(x, y));
 			} else if (windowPosition === "center") {


### PR DESCRIPTION
1. 替换了获取鼠标光标位置的`rust`库
2. `windows` 下获取的永远是 physical 尺寸，所以不需要考虑缩放比例 `scaleFactor=1`
> https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-getcursorpos