### PR TITLE
fix: 重命名mainBinaryName,保持Linux二进制文件名小写

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://schema.tauri.app/config/2.0.0",
 	"productName": "EcoPaste",
-	"mainBinaryName": "EcoPaste",
+	"mainBinaryName": "eco-paste",
 	"version": "../package.json",
 	"identifier": "com.ayangweb.EcoPaste",
 	"build": {


### PR DESCRIPTION
AUR不用改，我那会写的`*`通配

`mainBinaryName`就是控制构建后的二进制文件名的

appImage启动奔溃的问题还没找到，测试后发现与`mainBinaryName`和`productName`好像无关