### PR TITLE
fix: 当窗口位置选择屏幕中心时，拉伸窗口后，窗口无法被快捷键唤起

### DIFF
--- a/src/plugins/window.ts
+++ b/src/plugins/window.ts
@@ -77,7 +77,9 @@ export const toggleWindowVisible = async () => {
 						coordY = posY + (screenHeight - height) / 2;
 					}
 
-					await appWindow.setPosition(new PhysicalPosition(coordX, coordY));
+					await appWindow.setPosition(
+						new PhysicalPosition(Math.round(coordX), Math.round(coordY)),
+					);
 
 					break;
 				}


### PR DESCRIPTION
fix: #749