### PR TITLE
fix: 添加tauri必须依赖项webkit2gtk-4.1

### DIFF
--- a/.github/LINUX_AUR/preview/PKGBUILD
+++ b/.github/LINUX_AUR/preview/PKGBUILD
@@ -10,6 +10,7 @@ url="https://github.com/EcoPasteHub/EcoPaste"
 license=('Apache-2.0')
 provides=("eco-paste" "EcoPaste" "eco-paste-beta")
 conflicts=("eco-paste" "eco-paste-git" "eco-paste-appimage" "eco-paste-bin")
+depends=("webkit2gtk-4.1")
 optdepends=()
 _ocr_languages=(afr amh ara asm aze_cyrl aze bel ben bod bos bre bul cat ceb ces chi_sim chi_sim_vert
 chi_tra chi_tra_vert chr cos cym dan deu div dzo ell eng enm epo est eus fao fas fil fin fra frk

--- a/.github/LINUX_AUR/release/PKGBUILD
+++ b/.github/LINUX_AUR/release/PKGBUILD
@@ -9,6 +9,7 @@ url="https://github.com/EcoPasteHub/EcoPaste"
 license=('Apache-2.0')
 provides=("eco-paste" "EcoPaste" "eco-paste")
 conflicts=("eco-paste" "eco-paste-git" "eco-paste-appimage" "eco-paste-beta" "eco-paste-beta-bin")
+depends=("webkit2gtk-4.1")
 optdepends=()
 _ocr_languages=(afr amh ara asm aze_cyrl aze bel ben bod bos bre bul cat ceb ces chi_sim chi_sim_vert
 chi_tra chi_tra_vert chr cos cym dan deu div dzo ell eng enm epo est eus fao fas fil fin fra frk


### PR DESCRIPTION
把tauri的必须依赖项嵌入到AUR中自动安装https://v2.tauri.app/blog/tauri-2-0-0-alpha-3/