### PR TITLE
feat: 复制时，不保存指定类型的文件、文件大小限制

### DIFF
--- a/src/components/AdaptiveSelect/index.tsx
+++ b/src/components/AdaptiveSelect/index.tsx
@@ -1,14 +1,18 @@
-import { Select, type SelectProps } from "antd";
+import type { AdaptiveSelectProps } from "@/types/plugin";
+import { Select } from "antd";
 
 const DEFAULT_WIDTH = 100;
 
-const AdaptiveSelect = <T,>(props: SelectProps<T>) => {
-	const { style, ...rest } = props;
+const AdaptiveSelect = <T,>(props: AdaptiveSelectProps<T>) => {
+	const { style, expandWidth = 0, ...rest } = props;
 
 	const width = useCreation(() => {
 		if (!rest.options) return DEFAULT_WIDTH;
 
 		let width = 0;
+		if (props.expandWidth !== 0 && props.expandWidth !== undefined) {
+			width = props.expandWidth;
+		}
 
 		const canvas = document.createElement("canvas");
 		const context = canvas.getContext("2d");

--- a/src/components/ProSelect/index.tsx
+++ b/src/components/ProSelect/index.tsx
@@ -1,9 +1,9 @@
-import type { SelectProps } from "antd";
+import type { AdaptiveSelectProps } from "@/types/plugin";
 import type { ListItemMetaProps } from "antd/es/list";
 import AdaptiveSelect from "../AdaptiveSelect";
 import ProListItem from "../ProListItem";
 
-export type ProSelectProps<T> = SelectProps<T> & ListItemMetaProps;
+export type ProSelectProps<T> = AdaptiveSelectProps<T> & ListItemMetaProps;
 
 const SettingSelect = <T,>(props: ProSelectProps<T>) => {
 	const { title, description, children, ...rest } = props;

--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -70,7 +70,8 @@
 					"auto_favorite": "Auto Favorite",
 					"delete_confirm": "Delete Confirmation",
 					"auto_sort": "Auto Sort",
-					"show_original_content": "Show Original Content"
+					"show_original_content": "Show Original Content",
+					"excluded_file_types": "Exclude specified file types"
 				},
 				"hints": {
 					"auto_paste": "Quickly paste content to the input field when using the left mouse button",
@@ -81,7 +82,9 @@
 					"auto_favorite": "Auto-favorite after adding or editing a note",
 					"delete_confirm": "Pop-up confirmation dialog when deleting clipboard contents",
 					"auto_sort": "Alignment to the top when copying existing content",
-					"show_original_content": "Whether to display the original content on mouse hover after adding a note"
+					"show_original_content": "Whether to display the original content on mouse hover after adding a note",
+					"excluded_file_types": "When copying, do not save files of the specified type",
+					"excluded_file_types_placeholder": "For example .pdf .mp3"
 				}
 			}
 		},

--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -71,7 +71,8 @@
 					"delete_confirm": "Delete Confirmation",
 					"auto_sort": "Auto Sort",
 					"show_original_content": "Show Original Content",
-					"excluded_file_types": "Exclude specified file types"
+					"excluded_file_types": "Exclude specified file types",
+					"file_size_limit": "File size limit"
 				},
 				"hints": {
 					"auto_paste": "Quickly paste content to the input field when using the left mouse button",
@@ -84,7 +85,8 @@
 					"auto_sort": "Alignment to the top when copying existing content",
 					"show_original_content": "Whether to display the original content on mouse hover after adding a note",
 					"excluded_file_types": "When copying, do not save files of the specified type",
-					"excluded_file_types_placeholder": "For example .pdf .mp3"
+					"excluded_file_types_placeholder": "For example .pdf .mp3",
+					"file_size_limit": "File size limit, default 0 means no limit, if the file exceeds the specified size, the file will not be saved when copying"
 				}
 			}
 		},

--- a/src/locales/ja-JP.json
+++ b/src/locales/ja-JP.json
@@ -70,7 +70,8 @@
 					"auto_favorite": "自動コレクション",
 					"delete_confirm": "削除確認",
 					"auto_sort": "自動整列",
-					"show_original_content": "元の内容を表示します"
+					"show_original_content": "元の内容を表示します",
+					"excluded_file_types": "指定された種類のファイルを除外する"
 				},
 				"hints": {
 					"auto_paste": "左クリック時に、内容を素早く入力フィールドに貼り付けます",
@@ -81,7 +82,9 @@
 					"auto_favorite": "メモの追加・編集後に自動お気に入り登録",
 					"delete_confirm": "クリップボードの内容を削除する際に確認ダイアログを表示する",
 					"auto_sort": "既存の内容をコピーして最前面に配置する",
-					"show_original_content": "メモを追加した後、マウスをホバーしたときに元のコンテンツを表示するかどうか"
+					"show_original_content": "メモを追加した後、マウスをホバーしたときに元のコンテンツを表示するかどうか",
+					"excluded_file_types": "コピー時に、指定したタイプのファイルを保存しない",
+					"excluded_file_types_placeholder": "例えば .pdf .mp3"
 				}
 			}
 		},

--- a/src/locales/ja-JP.json
+++ b/src/locales/ja-JP.json
@@ -71,7 +71,8 @@
 					"delete_confirm": "削除確認",
 					"auto_sort": "自動整列",
 					"show_original_content": "元の内容を表示します",
-					"excluded_file_types": "指定された種類のファイルを除外する"
+					"excluded_file_types": "指定された種類のファイルを除外する",
+					"file_size_limit": "ファイルサイズの制限"
 				},
 				"hints": {
 					"auto_paste": "左クリック時に、内容を素早く入力フィールドに貼り付けます",
@@ -84,7 +85,8 @@
 					"auto_sort": "既存の内容をコピーして最前面に配置する",
 					"show_original_content": "メモを追加した後、マウスをホバーしたときに元のコンテンツを表示するかどうか",
 					"excluded_file_types": "コピー時に、指定したタイプのファイルを保存しない",
-					"excluded_file_types_placeholder": "例えば .pdf .mp3"
+					"excluded_file_types_placeholder": "例えば .pdf .mp3",
+					"file_size_limit": "ファイルサイズの制限。デフォルトは 0 で制限なし。ファイルが指定されたサイズを超えると、コピー時にファイルは保存されません"
 				}
 			}
 		},

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -70,7 +70,8 @@
 					"auto_favorite": "自动收藏",
 					"delete_confirm": "删除确认",
 					"auto_sort": "自动排序",
-					"show_original_content": "显示原内容"
+					"show_original_content": "显示原内容",
+					"excluded_file_types": "排除指定类型文件"
 				},
 				"hints": {
 					"auto_paste": "鼠标左键操作时，快速粘贴内容至输入位置",
@@ -81,7 +82,9 @@
 					"auto_favorite": "新增或编辑备注后自动收藏",
 					"delete_confirm": "删除剪贴板内容时弹出确认对话框",
 					"auto_sort": "复制已存在的内容时排列到最前面",
-					"show_original_content": "添加备注后，鼠标悬停时是否显示原内容"
+					"show_original_content": "添加备注后，鼠标悬停时是否显示原内容",
+					"excluded_file_types": "复制时，不保存指定类型的文件",
+					"excluded_file_types_placeholder": "例如 .pdf .mp3"
 				}
 			}
 		},

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -71,7 +71,8 @@
 					"delete_confirm": "删除确认",
 					"auto_sort": "自动排序",
 					"show_original_content": "显示原内容",
-					"excluded_file_types": "排除指定类型文件"
+					"excluded_file_types": "排除指定类型文件",
+					"file_size_limit": "文件大小限制"
 				},
 				"hints": {
 					"auto_paste": "鼠标左键操作时，快速粘贴内容至输入位置",
@@ -84,7 +85,8 @@
 					"auto_sort": "复制已存在的内容时排列到最前面",
 					"show_original_content": "添加备注后，鼠标悬停时是否显示原内容",
 					"excluded_file_types": "复制时，不保存指定类型的文件",
-					"excluded_file_types_placeholder": "例如 .pdf .mp3"
+					"excluded_file_types_placeholder": "例如 .pdf .mp3",
+					"file_size_limit": "文件大小限制，默认 0 不限制，超过指定大小则在复制时不保存该文件"
 				}
 			}
 		},

--- a/src/locales/zh-TW.json
+++ b/src/locales/zh-TW.json
@@ -71,7 +71,8 @@
 					"delete_confirm": "删除確認",
 					"auto_sort": "自動排序",
 					"show_original_content": "顯示原內容",
-					"excluded_file_types": "排除指定類型文件"
+					"excluded_file_types": "排除指定類型文件",
+					"file_size_limit": "檔案大小限制"
 				},
 				"hints": {
 					"auto_paste": "當使用滑鼠左鍵時，快速將內容貼上到輸入位置",
@@ -84,7 +85,8 @@
 					"auto_sort": "複製已存在的內容時排列到最前面",
 					"show_original_content": "添加備註後，滑鼠懸停時是否顯示原內容",
 					"excluded_file_types": "複製時，不保存指定類型的檔案",
-					"excluded_file_types_placeholder": "例如 .pdf .mp3"
+					"excluded_file_types_placeholder": "例如 .pdf .mp3",
+					"file_size_limit": "文件大小限制，預設 0 不限制，超過指定大小則在複製時不儲存該文件"
 				}
 			}
 		},

--- a/src/locales/zh-TW.json
+++ b/src/locales/zh-TW.json
@@ -70,7 +70,8 @@
 					"auto_favorite": "自動收藏",
 					"delete_confirm": "删除確認",
 					"auto_sort": "自動排序",
-					"show_original_content": "顯示原內容"
+					"show_original_content": "顯示原內容",
+					"excluded_file_types": "排除指定類型文件"
 				},
 				"hints": {
 					"auto_paste": "當使用滑鼠左鍵時，快速將內容貼上到輸入位置",
@@ -81,7 +82,9 @@
 					"auto_favorite": "新增或編輯備註後自動收藏",
 					"delete_confirm": "删除剪貼板內容時彈出確認對話方塊",
 					"auto_sort": "複製已存在的內容時排列到最前面",
-					"show_original_content": "添加備註後，滑鼠懸停時是否顯示原內容"
+					"show_original_content": "添加備註後，滑鼠懸停時是否顯示原內容",
+					"excluded_file_types": "複製時，不保存指定類型的檔案",
+					"excluded_file_types_placeholder": "例如 .pdf .mp3"
 				}
 			}
 		},

--- a/src/pages/Main/components/List/components/Item/index.tsx
+++ b/src/pages/Main/components/List/components/Item/index.tsx
@@ -361,6 +361,27 @@ const Item: FC<ItemProps> = (props) => {
 				>
 					{renderContent()}
 				</div>
+
+				{/* 数字标记 - 显示在右下角 */}
+				<div
+					className={clsx(
+						"absolute right-1 bottom-1 flex items-center justify-center rounded-full bg-blue-500 font-medium text-white shadow-sm",
+						{
+							// 1-2位数字：小圆圈
+							"h-5 w-5 text-xs": index + 1 < 100,
+							// 3位数字：中等圆圈
+							"h-6 w-6 text-xs": index + 1 >= 100 && index + 1 < 1000,
+							// 4位数字：大圆圈
+							"h-7 w-7 text-xs": index + 1 >= 1000 && index + 1 < 10000,
+							// 5位及以上：椭圆形
+							"h-6 rounded-full px-2 text-xs": index + 1 >= 10000,
+						},
+					)}
+				>
+					{index + 1 >= 10000
+						? `${Math.floor((index + 1) / 1000)}k`
+						: index + 1}
+				</div>
 			</div>
 		</Flex>
 	);

--- a/src/pages/Main/index.tsx
+++ b/src/pages/Main/index.tsx
@@ -1,5 +1,6 @@
 import type { AudioRef } from "@/components/Audio";
 import Audio from "@/components/Audio";
+import { clipboardStore } from "@/stores/clipboard.ts";
 import type { HistoryTablePayload, TablePayload } from "@/types/database";
 import type { Store } from "@/types/store";
 import type { EventEmitter } from "ahooks/lib/useEventEmitter";
@@ -53,6 +54,10 @@ const Main = () => {
 			}
 
 			const { type, value, group } = payload;
+
+			if (type === "files" && payload.count === 0) {
+				return;
+			}
 
 			const findItem = find(state.list, { type, value });
 

--- a/src/pages/Preference/components/Clipboard/components/ExcludeFileTypes/index.tsx
+++ b/src/pages/Preference/components/Clipboard/components/ExcludeFileTypes/index.tsx
@@ -1,0 +1,100 @@
+import ProSelect from "@/components/ProSelect";
+import type { SelectProps } from "antd";
+import { useSnapshot } from "valtio";
+
+const ExcludeFileTypes = () => {
+	const { excludeFiles } = useSnapshot(clipboardStore);
+	const { t } = useTranslation();
+
+	const options: SelectProps["options"] = [
+		{
+			value: ".txt",
+			label: ".txt",
+		},
+		{
+			value: ".pdf",
+			label: ".pdf",
+		},
+		{
+			value: ".mp3",
+			label: ".mp3",
+		},
+		{
+			value: ".mp4",
+			label: ".mp4",
+		},
+		{
+			value: ".avi",
+			label: ".avi",
+		},
+		{
+			value: ".png",
+			label: ".png",
+		},
+		{
+			value: ".jpg",
+			label: ".jpg",
+		},
+		{
+			value: ".gif",
+			label: ".gif",
+		},
+		{
+			value: ".doc",
+			label: ".doc",
+		},
+		{
+			value: ".docx",
+			label: ".docx",
+		},
+		{
+			value: ".xls",
+			label: ".xls",
+		},
+		{
+			value: ".xlsx",
+			label: ".xlsx",
+		},
+		{
+			value: ".ppt",
+			label: ".ppt",
+		},
+		{
+			value: ".pptx",
+			label: ".pptx",
+		},
+		{
+			value: ".zip",
+			label: ".zip",
+		},
+		{
+			value: ".rar",
+			label: ".rar",
+		},
+	];
+
+	return (
+		<>
+			<ProSelect
+				title={t(
+					"preference.clipboard.content_settings.label.excluded_file_types",
+				)}
+				description={t(
+					"preference.clipboard.content_settings.hints.excluded_file_types",
+				)}
+				mode="tags"
+				placeholder={t(
+					"preference.clipboard.content_settings.hints.excluded_file_types_placeholder",
+				)}
+				expandWidth={180}
+				options={options}
+				defaultValue={excludeFiles}
+				onChange={(value) => {
+					clipboardStore.excludeFiles = value as string[];
+				}}
+			/>
+		</>
+	);
+};
+
+export default ExcludeFileTypes;

--- a/src/pages/Preference/components/Clipboard/index.tsx
+++ b/src/pages/Preference/components/Clipboard/index.tsx
@@ -1,8 +1,9 @@
 import Audio from "@/components/Audio";
 import ProList from "@/components/ProList";
+import ProListItem from "@/components/ProListItem";
 import ProSwitch from "@/components/ProSwitch";
 import ExcludeFileTypes from "@/pages/Preference/components/Clipboard/components/ExcludeFileTypes";
-import { Typography } from "antd";
+import { InputNumber, Typography } from "antd";
 import { useSnapshot } from "valtio";
 import AutoPaste from "./components/AutoPaste";
 import OperationButton from "./components/OperationButton";
@@ -177,6 +178,29 @@ const ClipboardSettings = () => {
 				/>
 
 				<ExcludeFileTypes />
+
+				<ProListItem
+					title={t(
+						"preference.clipboard.content_settings.label.file_size_limit",
+					)}
+					description={t(
+						"preference.clipboard.content_settings.hints.file_size_limit",
+					)}
+				>
+					<InputNumber<number>
+						defaultValue={clipboardStore.fileSizeLimit}
+						min={0}
+						formatter={(value) => `${value} MB`}
+						parser={(value) => value?.replace(" MB", "") as unknown as number}
+						onChange={(value) => {
+							if (typeof value === "number") {
+								clipboardStore.fileSizeLimit = value;
+							} else {
+								clipboardStore.fileSizeLimit = 0;
+							}
+						}}
+					/>
+				</ProListItem>
 			</ProList>
 		</>
 	);

--- a/src/pages/Preference/components/Clipboard/index.tsx
+++ b/src/pages/Preference/components/Clipboard/index.tsx
@@ -1,6 +1,7 @@
 import Audio from "@/components/Audio";
 import ProList from "@/components/ProList";
 import ProSwitch from "@/components/ProSwitch";
+import ExcludeFileTypes from "@/pages/Preference/components/Clipboard/components/ExcludeFileTypes";
 import { Typography } from "antd";
 import { useSnapshot } from "valtio";
 import AutoPaste from "./components/AutoPaste";
@@ -174,6 +175,8 @@ const ClipboardSettings = () => {
 						clipboardStore.content.showOriginalContent = value;
 					}}
 				/>
+
+				<ExcludeFileTypes />
 			</ProList>
 		</>
 	);

--- a/src/plugins/clipboard.ts
+++ b/src/plugins/clipboard.ts
@@ -108,12 +108,27 @@ export const readFiles = async (): Promise<ClipboardPayload> => {
 		});
 	}
 
+	const excludeBigFiles: string[] = [];
+
 	for await (const path of files) {
 		const { size, name } = await metadata(path);
-
+		if (
+			clipboardStore.fileSizeLimit !== 0 &&
+			size >= clipboardStore.fileSizeLimit * 1024 * 1024
+		) {
+			excludeBigFiles.push(path);
+			continue;
+		}
 		count += size;
 
 		names.push(name);
+	}
+
+	// 排除文件大小超过限制的文件
+	if (excludeBigFiles.length > 0) {
+		files = files.filter((file) => {
+			return !excludeBigFiles.includes(file);
+		});
 	}
 
 	return {

--- a/src/plugins/clipboard.ts
+++ b/src/plugins/clipboard.ts
@@ -1,3 +1,4 @@
+import { clipboardStore } from "@/stores/clipboard.ts";
 import type { HistoryTablePayload } from "@/types/database";
 import type { ClipboardPayload, ReadImage, WindowsOCR } from "@/types/plugin";
 import { invoke } from "@tauri-apps/api/core";
@@ -96,6 +97,16 @@ export const readFiles = async (): Promise<ClipboardPayload> => {
 	let count = 0;
 
 	const names = [];
+
+	// 获取需要排除的文件类型
+	const excludeFiles = clipboardStore.excludeFiles;
+	// 移除指定的文件类型
+	if (excludeFiles.length > 0 && files.length > 0) {
+		files = files.filter((file) => {
+			const ext = file.slice(file.lastIndexOf("."));
+			return !excludeFiles.includes(ext);
+		});
+	}
 
 	for await (const path of files) {
 		const { size, name } = await metadata(path);

--- a/src/stores/clipboard.ts
+++ b/src/stores/clipboard.ts
@@ -38,4 +38,6 @@ export const clipboardStore = proxy<ClipboardStore>({
 	},
 
 	excludeFiles: [],
+
+	fileSizeLimit: 0,
 });

--- a/src/stores/clipboard.ts
+++ b/src/stores/clipboard.ts
@@ -36,4 +36,6 @@ export const clipboardStore = proxy<ClipboardStore>({
 		unit: 1,
 		maxCount: 0,
 	},
+
+	excludeFiles: [],
 });

--- a/src/types/plugin.d.ts
+++ b/src/types/plugin.d.ts
@@ -1,3 +1,5 @@
+import type { SelectProps } from "antd";
+
 export type WindowLabel = (typeof WINDOW_LABEL)[keyof typeof WINDOW_LABEL];
 
 export interface ReadImage {
@@ -23,4 +25,8 @@ export interface WindowsOCR {
 		bounds: Array<{ x: number; y: number }>;
 		content: string;
 	}>;
+}
+
+export interface AdaptiveSelectProps<T> extends SelectProps<T> {
+	expandWidth?: number;
 }

--- a/src/types/store.d.ts
+++ b/src/types/store.d.ts
@@ -99,4 +99,7 @@ export interface ClipboardStore {
 		unit: number;
 		maxCount: number;
 	};
+
+	// 排除的文件类型
+	excludeFiles: string[];
 }

--- a/src/types/store.d.ts
+++ b/src/types/store.d.ts
@@ -102,4 +102,7 @@ export interface ClipboardStore {
 
 	// 排除的文件类型
 	excludeFiles: string[];
+
+	// 文件大小限制
+	fileSizeLimit: number;
 }


### PR DESCRIPTION
相关 issues：#569

![image](https://github.com/user-attachments/assets/869d95c1-0d6f-4af2-b798-4bf61c5beea9)

1. 可以选择或者新增文件类型，在复制粘贴时不保存这些类型的文件（多个文件仍然可以生效，文件夹不会生效）

![image](https://github.com/user-attachments/assets/1d8b9ea1-8c64-4194-9594-18cff2987223)

2. 文件大小限制：对于大于指定文件大小的文件不进行保存（多个文件仍然可以生效，文件夹不会生效）

![image](https://github.com/user-attachments/assets/44b95c81-7c8a-4024-9b81-fcb789741caf)
