### PR TITLE
fix: implement 'switch to all group when activated' feature

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
 		"@tauri-apps/plugin-dialog": "^2.4.0",
 		"@tauri-apps/plugin-fs": "^2.4.2",
 		"@tauri-apps/plugin-global-shortcut": "^2.3.0",
+		"@tauri-apps/plugin-http": "^2.0.0",
 		"@tauri-apps/plugin-log": "^2.7.0",
 		"@tauri-apps/plugin-opener": "^2.5.0",
 		"@tauri-apps/plugin-os": "^2.3.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
       '@tauri-apps/plugin-global-shortcut':
         specifier: ^2.3.0
         version: 2.3.0
+      '@tauri-apps/plugin-http':
+        specifier: ^2.0.0
+        version: 2.5.4
       '@tauri-apps/plugin-log':
         specifier: ^2.7.0
         version: 2.7.0
@@ -1418,6 +1421,9 @@ packages:
 
   '@tauri-apps/plugin-global-shortcut@2.3.0':
     resolution: {integrity: sha512-WbAz0ElhpP+0kzQZRScdCC7UQ7OPH8PAn//fsBNu7+ywihsnVSVOg1L9YhieAtLNtAlnmFI69Yl5AGaA3ge5IQ==}
+
+  '@tauri-apps/plugin-http@2.5.4':
+    resolution: {integrity: sha512-/i4U/9za3mrytTgfRn5RHneKubZE/dwRmshYwyMvNRlkWjvu1m4Ma72kcbVJMZFGXpkbl+qLyWMGrihtWB76Zg==}
 
   '@tauri-apps/plugin-log@2.7.0':
     resolution: {integrity: sha512-81XQ2f93x4vmIB5OY0XlYAxy60cHdYLs0Ki8Qp38tNATRiuBit+Orh3frpY3qfYQnqEvYVyRub7YRJWlmW2RRA==}
@@ -5480,6 +5486,10 @@ snapshots:
       '@tauri-apps/api': 2.8.0
 
   '@tauri-apps/plugin-global-shortcut@2.3.0':
+    dependencies:
+      '@tauri-apps/api': 2.8.0
+
+  '@tauri-apps/plugin-http@2.5.4':
     dependencies:
       '@tauri-apps/api': 2.8.0
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -26,6 +26,7 @@ tauri-plugin-autostart = "2"
 tauri-plugin-sql = { version = "2", features = ["sqlite"] }
 tauri-plugin-log = "2"
 tauri-plugin-global-shortcut = "2"
+tauri-plugin-http = { version = "2", features = ["default"] }
 tauri-plugin-os = "2"
 tauri-plugin-dialog = "2"   
 tauri-plugin-fs = "2"

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -43,7 +43,19 @@
     "clipboard-x:default",
     "eco-window:default",
     "eco-paste:default",
-    "eco-autostart:default"
+    "eco-autostart:default",
+    "http:default",
+    {
+      "allow": [
+        {
+          "url": "https://*"
+        },
+        {
+          "url": "http://*"
+        }
+      ],
+      "identifier": "http:allow-fetch"
+    }
   ],
   "windows": ["*"]
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -51,6 +51,8 @@ pub fn run() {
         .plugin(tauri_plugin_dialog::init())
         // 访问文件系统插件：https://github.com/tauri-apps/tauri-plugin-fs
         .plugin(tauri_plugin_fs::init())
+        // HTTP 请求插件：https://github.com/tauri-apps/plugins-workspace/tree/v2/plugins/http
+        .plugin(tauri_plugin_http::init())
         // 更新插件：https://github.com/tauri-apps/tauri-plugin-updater
         .plugin(tauri_plugin_updater::Builder::new().build())
         // 进程相关插件：https://github.com/tauri-apps/tauri-plugin-process

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -50,6 +50,24 @@
           "effects": ["sidebar"],
           "state": "active"
         }
+      },
+      {
+        "acceptFirstMouse": true,
+        "alwaysOnTop": true,
+        "center": true,
+        "decorations": false,
+        "height": 500,
+        "label": "ocr",
+        "maximizable": false,
+        "minHeight": 300,
+        "minWidth": 400,
+        "resizable": true,
+        "skipTaskbar": true,
+        "title": "OCR",
+        "transparent": true,
+        "url": "index.html/#/ocr",
+        "visible": false,
+        "width": 450
       }
     ]
   },

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -22,6 +22,7 @@ export const LANGUAGE = {
 
 export const LISTEN_KEY = {
   ACTIVATE_BACK_TOP: "activate-back-top",
+  ACTIVATE_SHOW_ALL: "activate-show-all",
   CLIPBOARD_ITEM_DELETE: "clipboard-item-delete",
   CLIPBOARD_ITEM_FAVORITE: "clipboard-item-favorite",
   CLIPBOARD_ITEM_PASTE: "clipboard-item-paste",

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -10,6 +10,7 @@ export const UPDATE_MESSAGE_KEY = "app-update-message";
 
 export const WINDOW_LABEL = {
   MAIN: "main",
+  OCR: "ocr",
   PREFERENCE: "preference",
 } as const;
 
@@ -30,6 +31,8 @@ export const LISTEN_KEY = {
   CLIPBOARD_ITEM_SELECT_NEXT: "clipboard-item-select-next",
   CLIPBOARD_ITEM_SELECT_PREV: "clipboard-item-select-prev",
   CLOSE_DATABASE: "close-database",
+  OCR_START: "ocr-start",
+  OCR_TRANSLATE_START: "ocr-translate-start",
   REFRESH_CLIPBOARD_LIST: "refresh-clipboard-list",
   SHOW_WINDOW: "show-window",
   STORE_CHANGED: "store-changed",

--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -253,7 +253,64 @@
         "clipboard": "Clipboard",
         "general": "General",
         "history": "History",
+        "ocr": "OCR",
         "shortcut": "Shortcuts"
+      }
+    },
+    "ocr": {
+      "api_settings": {
+        "hints": {
+          "api_base": "OpenAI-compatible API endpoint",
+          "api_key": "API key for authentication",
+          "model": "Vision model name that supports image recognition"
+        },
+        "label": {
+          "api_base": "API Base URL",
+          "api_key": "API Key",
+          "model": "Model Name"
+        },
+        "title": "OCR API Settings"
+      },
+      "behavior_settings": {
+        "hints": {
+          "auto_copy": "Automatically copy OCR result to clipboard"
+        },
+        "label": {
+          "auto_copy": "Auto Copy Result"
+        },
+        "title": "Behavior Settings"
+      },
+      "shortcut_settings": {
+        "hints": {
+          "ocr": "Capture screen and recognize text in the image",
+          "ocr_translate": "Capture, recognize text, then translate"
+        },
+        "label": {
+          "ocr": "OCR Recognition",
+          "ocr_translate": "OCR + Translation"
+        },
+        "title": "Shortcut Settings"
+      },
+      "translate_settings": {
+        "hints": {
+          "api_base": "Leave empty to use OCR API settings",
+          "api_key": "Leave empty to use OCR API key",
+          "model": "Leave empty to use OCR model",
+          "target_language": "Target language for translation"
+        },
+        "label": {
+          "api_base": "Translation API URL",
+          "api_key": "Translation API Key",
+          "enabled": "Enable Translation",
+          "model": "Translation Model",
+          "target_language": "Target Language"
+        },
+        "placeholder": {
+          "api_base": "Use OCR settings",
+          "api_key": "Use OCR settings",
+          "model": "Use OCR settings"
+        },
+        "title": "Translation Settings"
       }
     },
     "settings": {

--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -262,28 +262,36 @@
         "hints": {
           "api_base": "OpenAI-compatible API endpoint",
           "api_key": "API key for authentication",
-          "model": "Vision model name that supports image recognition"
+          "model": "Vision model name that supports image recognition",
+          "prompt": "OCR prompt sent to the vision model"
         },
         "label": {
           "api_base": "API Base URL",
           "api_key": "API Key",
-          "model": "Model Name"
+          "model": "Model Name",
+          "prompt": "OCR Prompt"
         },
         "title": "OCR API Settings"
       },
       "behavior_settings": {
         "hints": {
-          "auto_copy": "Automatically copy OCR result to clipboard"
+          "auto_copy": "Automatically copy OCR result to clipboard",
+          "hide_main_window": "Hide main window when OCR is triggered",
+          "save_history": "Save OCR recognition history",
+          "window_pinned": "OCR window stays on top by default"
         },
         "label": {
-          "auto_copy": "Auto Copy Result"
+          "auto_copy": "Auto Copy Result",
+          "hide_main_window": "Hide Main Window",
+          "save_history": "Save History",
+          "window_pinned": "Pin Window"
         },
         "title": "Behavior Settings"
       },
       "shortcut_settings": {
         "hints": {
-          "ocr": "Capture screen and recognize text in the image",
-          "ocr_translate": "Capture, recognize text, then translate"
+          "ocr": "Read image from clipboard and recognize text",
+          "ocr_translate": "Recognize text and auto-translate"
         },
         "label": {
           "ocr": "OCR Recognition",
@@ -296,6 +304,7 @@
           "api_base": "Leave empty to use OCR API settings",
           "api_key": "Leave empty to use OCR API key",
           "model": "Leave empty to use OCR model",
+          "system_prompt": "System prompt for translation, use $targetLanguage as target language variable",
           "target_language": "Target language for translation"
         },
         "label": {
@@ -303,6 +312,7 @@
           "api_key": "Translation API Key",
           "enabled": "Enable Translation",
           "model": "Translation Model",
+          "system_prompt": "Translation System Prompt",
           "target_language": "Target Language"
         },
         "placeholder": {

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -253,7 +253,64 @@
         "clipboard": "剪贴板",
         "general": "通用设置",
         "history": "历史记录",
+        "ocr": "OCR 识别",
         "shortcut": "快捷键"
+      }
+    },
+    "ocr": {
+      "api_settings": {
+        "hints": {
+          "api_base": "支持 OpenAI 格式的 API 地址",
+          "api_key": "API 密钥用于身份验证",
+          "model": "支持图像识别的视觉模型名称"
+        },
+        "label": {
+          "api_base": "API 地址",
+          "api_key": "API 密钥",
+          "model": "模型名称"
+        },
+        "title": "OCR API 设置"
+      },
+      "behavior_settings": {
+        "hints": {
+          "auto_copy": "OCR 识别完成后自动复制结果到剪贴板"
+        },
+        "label": {
+          "auto_copy": "自动复制结果"
+        },
+        "title": "行为设置"
+      },
+      "shortcut_settings": {
+        "hints": {
+          "ocr": "截图并识别图片中的文字",
+          "ocr_translate": "截图识别文字后自动翻译"
+        },
+        "label": {
+          "ocr": "OCR 识别",
+          "ocr_translate": "OCR + 翻译"
+        },
+        "title": "快捷键设置"
+      },
+      "translate_settings": {
+        "hints": {
+          "api_base": "留空则使用 OCR 的 API 配置",
+          "api_key": "留空则使用 OCR 的 API 密钥",
+          "model": "留空则使用 OCR 的模型",
+          "target_language": "翻译的目标语言"
+        },
+        "label": {
+          "api_base": "翻译 API 地址",
+          "api_key": "翻译 API 密钥",
+          "enabled": "启用翻译功能",
+          "model": "翻译模型",
+          "target_language": "目标语言"
+        },
+        "placeholder": {
+          "api_base": "留空使用 OCR 配置",
+          "api_key": "留空使用 OCR 配置",
+          "model": "留空使用 OCR 配置"
+        },
+        "title": "翻译设置"
       }
     },
     "settings": {

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -262,28 +262,36 @@
         "hints": {
           "api_base": "支持 OpenAI 格式的 API 地址",
           "api_key": "API 密钥用于身份验证",
-          "model": "支持图像识别的视觉模型名称"
+          "model": "支持图像识别的视觉模型名称",
+          "prompt": "发送给视觉模型的 OCR 识别提示词"
         },
         "label": {
           "api_base": "API 地址",
           "api_key": "API 密钥",
-          "model": "模型名称"
+          "model": "模型名称",
+          "prompt": "OCR 提示词"
         },
         "title": "OCR API 设置"
       },
       "behavior_settings": {
         "hints": {
-          "auto_copy": "OCR 识别完成后自动复制结果到剪贴板"
+          "auto_copy": "OCR 识别完成后自动复制结果到剪贴板",
+          "hide_main_window": "触发 OCR 时自动隐藏主窗口",
+          "save_history": "保存 OCR 识别历史记录",
+          "window_pinned": "OCR 窗口默认固定在最前面"
         },
         "label": {
-          "auto_copy": "自动复制结果"
+          "auto_copy": "自动复制结果",
+          "hide_main_window": "隐藏主窗口",
+          "save_history": "保存历史",
+          "window_pinned": "窗口固定"
         },
         "title": "行为设置"
       },
       "shortcut_settings": {
         "hints": {
-          "ocr": "截图并识别图片中的文字",
-          "ocr_translate": "截图识别文字后自动翻译"
+          "ocr": "从剪贴板读取图片并识别文字",
+          "ocr_translate": "识别文字后自动翻译"
         },
         "label": {
           "ocr": "OCR 识别",
@@ -296,6 +304,7 @@
           "api_base": "留空则使用 OCR 的 API 配置",
           "api_key": "留空则使用 OCR 的 API 密钥",
           "model": "留空则使用 OCR 的模型",
+          "system_prompt": "发送给翻译模型的系统提示词，可使用 $targetLanguage 作为目标语言变量",
           "target_language": "翻译的目标语言"
         },
         "label": {
@@ -303,6 +312,7 @@
           "api_key": "翻译 API 密钥",
           "enabled": "启用翻译功能",
           "model": "翻译模型",
+          "system_prompt": "翻译系统提示词",
           "target_language": "目标语言"
         },
         "placeholder": {

--- a/src/pages/Main/index.tsx
+++ b/src/pages/Main/index.tsx
@@ -69,6 +69,11 @@ const Main = () => {
     state.eventBus = eventBus;
   });
 
+  // 激活时切换至全部分组
+  useTauriListen(LISTEN_KEY.ACTIVATE_SHOW_ALL, () => {
+    state.group = "all";
+  });
+
   useClipboard(state, {
     beforeRead() {
       if (!clipboardStore.audio.copy) return;

--- a/src/pages/OCR/index.module.scss
+++ b/src/pages/OCR/index.module.scss
@@ -1,0 +1,125 @@
+.container {
+  height: 100vh;
+  background: var(--ant-color-bg-container);
+  border-radius: 12px;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+.titleBar {
+  padding: 8px 12px;
+  -webkit-app-region: drag;
+
+  .pinButton,
+  .closeButton {
+    -webkit-app-region: no-drag;
+    opacity: 0.6;
+    transition: all 0.2s;
+
+    &:hover {
+      opacity: 1;
+    }
+  }
+
+  .pinButton {
+    &.pinned {
+      opacity: 1;
+      color: var(--ant-color-primary);
+      transform: rotate(45deg);
+    }
+  }
+
+  .closeButton {
+    &:hover {
+      background: var(--ant-color-error-bg);
+      color: var(--ant-color-error);
+    }
+  }
+}
+
+.resultSection {
+  flex: 1;
+  padding: 0 16px 12px;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+.textArea {
+  flex: 1;
+  min-height: 80px;
+  max-height: 200px;
+  overflow-y: auto;
+  padding: 12px;
+  background: var(--ant-color-bg-elevated);
+  border-radius: 8px;
+  margin-bottom: 8px;
+
+  .text {
+    margin: 0;
+    font-family: inherit;
+    font-size: 14px;
+    line-height: 1.6;
+    white-space: pre-wrap;
+    word-break: break-word;
+    color: var(--ant-color-text);
+  }
+
+  .error {
+    color: var(--ant-color-error);
+    font-size: 13px;
+  }
+}
+
+.actionBar {
+  .spacer {
+    flex: 1;
+  }
+
+  .languageTag {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 4px 10px;
+    background: var(--ant-color-primary-bg);
+    border-radius: 12px;
+    font-size: 12px;
+    color: var(--ant-color-primary);
+  }
+}
+
+.modelInfo {
+  padding: 8px 12px;
+  margin-bottom: 8px;
+  background: var(--ant-color-bg-elevated);
+  border-radius: 8px;
+  font-size: 13px;
+  color: var(--ant-color-text-secondary);
+
+  .spacer {
+    flex: 1;
+  }
+}
+
+.divider {
+  margin: 0;
+}
+
+// 滚动条样式
+.textArea::-webkit-scrollbar {
+  width: 6px;
+}
+
+.textArea::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.textArea::-webkit-scrollbar-thumb {
+  background: var(--ant-color-border);
+  border-radius: 3px;
+}
+
+.textArea::-webkit-scrollbar-thumb:hover {
+  background: var(--ant-color-border-secondary);
+}

--- a/src/pages/OCR/index.tsx
+++ b/src/pages/OCR/index.tsx
@@ -1,0 +1,321 @@
+import { useMount, useReactive } from "ahooks";
+import { Button, Divider, Flex, message, Spin, Tooltip } from "antd";
+import clsx from "clsx";
+import { writeText } from "tauri-plugin-clipboard-x-api";
+import { useSnapshot } from "valtio";
+import UnoIcon from "@/components/UnoIcon";
+import { LISTEN_KEY } from "@/constants";
+import { useTauriListen } from "@/hooks/useTauriListen";
+import { hideWindow } from "@/plugins/window";
+import { performOcr } from "@/services/ocr/openai";
+import { translate } from "@/services/translate/openai";
+import { globalStore } from "@/stores/global";
+import styles from "./index.module.scss";
+
+interface State {
+  ocrText: string;
+  translateText: string;
+  ocrLoading: boolean;
+  translateLoading: boolean;
+  pinned: boolean;
+  ocrError?: string;
+  translateError?: string;
+  sourceLanguage: string;
+}
+
+const INITIAL_STATE: State = {
+  ocrError: undefined,
+  ocrLoading: false,
+  ocrText: "",
+  pinned: false,
+  sourceLanguage: "auto",
+  translateError: undefined,
+  translateLoading: false,
+  translateText: "",
+};
+
+const OCR = () => {
+  const { ocr } = useSnapshot(globalStore);
+  const state = useReactive<State>(INITIAL_STATE);
+
+  useMount(() => {
+    state.pinned = ocr.windowPinned;
+  });
+
+  // 监听 OCR 开始事件
+  useTauriListen<{ imageBase64: string; withTranslate: boolean }>(
+    LISTEN_KEY.OCR_START,
+    async ({ payload }) => {
+      const { imageBase64, withTranslate } = payload;
+      await handleOcr(imageBase64, withTranslate);
+    },
+  );
+
+  // 执行 OCR
+  const handleOcr = async (imageBase64: string, withTranslate: boolean) => {
+    state.ocrLoading = true;
+    state.ocrError = undefined;
+    state.ocrText = "";
+    state.translateText = "";
+    state.translateError = undefined;
+
+    try {
+      const result = await performOcr(imageBase64, {
+        apiBase: globalStore.ocr.apiBase,
+        apiKey: globalStore.ocr.apiKey,
+        model: globalStore.ocr.model,
+        prompt: globalStore.ocr.prompt,
+      });
+
+      if (result.success) {
+        state.ocrText = result.text;
+
+        // 自动复制
+        if (globalStore.ocr.autoCopy) {
+          await writeText(result.text);
+        }
+
+        // 执行翻译
+        if (withTranslate && globalStore.ocr.translate.enabled) {
+          await handleTranslate(result.text);
+        }
+      } else {
+        state.ocrError = result.error;
+      }
+    } catch (error) {
+      state.ocrError = String(error);
+    } finally {
+      state.ocrLoading = false;
+    }
+  };
+
+  // 执行翻译
+  const handleTranslate = async (text: string) => {
+    state.translateLoading = true;
+    state.translateError = undefined;
+
+    try {
+      const translateConfig = globalStore.ocr.translate;
+      const result = await translate(text, {
+        apiBase: translateConfig.apiBase || globalStore.ocr.apiBase,
+        apiKey: translateConfig.apiKey || globalStore.ocr.apiKey,
+        model: translateConfig.model || globalStore.ocr.model,
+        systemPrompt: translateConfig.systemPrompt,
+        targetLanguage: translateConfig.targetLanguage,
+      });
+
+      if (result.success) {
+        state.translateText = result.text;
+
+        // 翻译完成后自动复制翻译结果
+        if (globalStore.ocr.autoCopy) {
+          await writeText(result.text);
+        }
+      } else {
+        state.translateError = result.error;
+      }
+    } catch (error) {
+      state.translateError = String(error);
+    } finally {
+      state.translateLoading = false;
+    }
+  };
+
+  // 复制文本
+  const handleCopy = async (text: string) => {
+    await writeText(text);
+    message.success("已复制");
+  };
+
+  // 切换固定状态
+  const togglePinned = () => {
+    state.pinned = !state.pinned;
+    globalStore.ocr.windowPinned = state.pinned;
+  };
+
+  // 关闭窗口
+  const handleClose = () => {
+    hideWindow();
+  };
+
+  // 重新翻译
+  const handleRetranslate = async () => {
+    if (state.ocrText) {
+      await handleTranslate(state.ocrText);
+    }
+  };
+
+  return (
+    <Flex className={styles.container} vertical>
+      {/* 标题栏 */}
+      <Flex
+        align="center"
+        className={styles.titleBar}
+        data-tauri-drag-region
+        justify="space-between"
+      >
+        <Tooltip title={state.pinned ? "取消固定" : "固定窗口"}>
+          <Button
+            className={clsx(styles.pinButton, {
+              [styles.pinned]: state.pinned,
+            })}
+            icon={<UnoIcon name="i-lucide:pin" size={16} />}
+            onClick={togglePinned}
+            type="text"
+          />
+        </Tooltip>
+
+        <Button
+          className={styles.closeButton}
+          icon={<UnoIcon name="i-lucide:x" size={16} />}
+          onClick={handleClose}
+          shape="circle"
+          type="text"
+        />
+      </Flex>
+
+      {/* OCR 结果区域 */}
+      <Flex className={styles.resultSection} vertical>
+        <Spin spinning={state.ocrLoading} tip="正在识别...">
+          <div className={styles.textArea}>
+            {state.ocrError ? (
+              <div className={styles.error}>{state.ocrError}</div>
+            ) : (
+              <pre className={styles.text}>
+                {state.ocrText || "等待截图..."}
+              </pre>
+            )}
+          </div>
+        </Spin>
+
+        {/* OCR 操作按钮 */}
+        <Flex align="center" className={styles.actionBar} gap="small">
+          <Tooltip title="朗读">
+            <Button
+              disabled={!state.ocrText}
+              icon={<UnoIcon name="i-lucide:volume-2" size={14} />}
+              size="small"
+              type="text"
+            />
+          </Tooltip>
+          <Tooltip title="复制">
+            <Button
+              disabled={!state.ocrText}
+              icon={<UnoIcon name="i-lucide:copy" size={14} />}
+              onClick={() => handleCopy(state.ocrText)}
+              size="small"
+              type="text"
+            />
+          </Tooltip>
+          <Tooltip title="重新识别">
+            <Button
+              disabled={!state.ocrText}
+              icon={<UnoIcon name="i-lucide:refresh-cw" size={14} />}
+              size="small"
+              type="text"
+            />
+          </Tooltip>
+          <Tooltip title="删除">
+            <Button
+              disabled={!state.ocrText}
+              icon={<UnoIcon name="i-lucide:trash-2" size={14} />}
+              onClick={() => {
+                state.ocrText = "";
+              }}
+              size="small"
+              type="text"
+            />
+          </Tooltip>
+
+          <div className={styles.spacer} />
+
+          <span className={styles.languageTag}>
+            <UnoIcon name="i-lucide:circle" size={8} />
+            {state.sourceLanguage === "auto"
+              ? "自动检测"
+              : state.sourceLanguage}
+          </span>
+
+          <Tooltip title="翻译">
+            <Button
+              disabled={!state.ocrText || state.translateLoading}
+              icon={<UnoIcon name="i-lucide:languages" size={14} />}
+              onClick={handleRetranslate}
+              size="small"
+              type="text"
+            />
+          </Tooltip>
+        </Flex>
+      </Flex>
+
+      {/* 翻译结果区域（只有启用翻译时才显示） */}
+      {ocr.translate.enabled && (
+        <>
+          <Divider className={styles.divider} />
+
+          <Flex className={styles.resultSection} vertical>
+            <Flex align="center" className={styles.modelInfo} gap="small">
+              <UnoIcon name="i-lucide:bot" size={16} />
+              <span>{ocr.translate.model || ocr.model}</span>
+
+              <div className={styles.spacer} />
+
+              <Button
+                icon={<UnoIcon name="i-lucide:x" size={12} />}
+                onClick={() => {
+                  state.translateText = "";
+                }}
+                size="small"
+                type="text"
+              />
+            </Flex>
+
+            <Spin spinning={state.translateLoading} tip="正在翻译...">
+              <div className={styles.textArea}>
+                {state.translateError ? (
+                  <div className={styles.error}>{state.translateError}</div>
+                ) : (
+                  <pre className={styles.text}>
+                    {state.translateText || "等待翻译..."}
+                  </pre>
+                )}
+              </div>
+            </Spin>
+
+            {/* 翻译操作按钮 */}
+            <Flex align="center" className={styles.actionBar} gap="small">
+              <Tooltip title="朗读">
+                <Button
+                  disabled={!state.translateText}
+                  icon={<UnoIcon name="i-lucide:volume-2" size={14} />}
+                  size="small"
+                  type="text"
+                />
+              </Tooltip>
+              <Tooltip title="复制">
+                <Button
+                  disabled={!state.translateText}
+                  icon={<UnoIcon name="i-lucide:copy" size={14} />}
+                  onClick={() => handleCopy(state.translateText)}
+                  size="small"
+                  type="text"
+                />
+              </Tooltip>
+              <Tooltip title="重新翻译">
+                <Button
+                  disabled={!state.ocrText}
+                  icon={<UnoIcon name="i-lucide:refresh-cw" size={14} />}
+                  onClick={handleRetranslate}
+                  size="small"
+                  type="text"
+                />
+              </Tooltip>
+            </Flex>
+          </Flex>
+        </>
+      )}
+    </Flex>
+  );
+};
+
+export default OCR;

--- a/src/pages/Preference/components/OCR/index.tsx
+++ b/src/pages/Preference/components/OCR/index.tsx
@@ -1,4 +1,5 @@
 import { Input, Select } from "antd";
+import TextArea from "antd/es/input/TextArea";
 import { useTranslation } from "react-i18next";
 import { useSnapshot } from "valtio";
 import ProList from "@/components/ProList";
@@ -17,6 +18,9 @@ const LANGUAGE_OPTIONS = [
   { label: "Deutsch", value: "de" },
   { label: "Español", value: "es" },
   { label: "Русский", value: "ru" },
+  { label: "Português", value: "pt" },
+  { label: "Italiano", value: "it" },
+  { label: "العربية", value: "ar" },
 ];
 
 const OCRSettings = () => {
@@ -25,6 +29,7 @@ const OCRSettings = () => {
 
   return (
     <>
+      {/* API 设置 */}
       <ProList header={t("preference.ocr.api_settings.title")}>
         <ProListItem
           description={t("preference.ocr.api_settings.hints.api_base")}
@@ -67,8 +72,24 @@ const OCRSettings = () => {
             value={ocr.model}
           />
         </ProListItem>
+
+        <ProListItem
+          description={t("preference.ocr.api_settings.hints.prompt")}
+          title={t("preference.ocr.api_settings.label.prompt")}
+        >
+          <TextArea
+            autoSize={{ maxRows: 4, minRows: 2 }}
+            onChange={(e) => {
+              globalStore.ocr.prompt = e.target.value;
+            }}
+            placeholder="请识别图片中的文字..."
+            style={{ width: 300 }}
+            value={ocr.prompt}
+          />
+        </ProListItem>
       </ProList>
 
+      {/* 翻译设置 */}
       <ProList header={t("preference.ocr.translate_settings.title")}>
         <ProSwitch
           onChange={(value) => {
@@ -141,8 +162,26 @@ const OCRSettings = () => {
             value={ocr.translate.model}
           />
         </ProListItem>
+
+        <ProListItem
+          description={t(
+            "preference.ocr.translate_settings.hints.system_prompt",
+          )}
+          title={t("preference.ocr.translate_settings.label.system_prompt")}
+        >
+          <TextArea
+            autoSize={{ maxRows: 4, minRows: 2 }}
+            onChange={(e) => {
+              globalStore.ocr.translate.systemPrompt = e.target.value;
+            }}
+            placeholder="You are a professional translator..."
+            style={{ width: 300 }}
+            value={ocr.translate.systemPrompt}
+          />
+        </ProListItem>
       </ProList>
 
+      {/* 快捷键设置 */}
       <ProList header={t("preference.ocr.shortcut_settings.title")}>
         <ProShortcut
           description={t("preference.ocr.shortcut_settings.hints.ocr")}
@@ -165,6 +204,7 @@ const OCRSettings = () => {
         />
       </ProList>
 
+      {/* 行为设置 */}
       <ProList header={t("preference.ocr.behavior_settings.title")}>
         <ProSwitch
           description={t("preference.ocr.behavior_settings.hints.auto_copy")}
@@ -173,6 +213,37 @@ const OCRSettings = () => {
           }}
           title={t("preference.ocr.behavior_settings.label.auto_copy")}
           value={ocr.autoCopy}
+        />
+
+        <ProSwitch
+          description={t(
+            "preference.ocr.behavior_settings.hints.window_pinned",
+          )}
+          onChange={(value) => {
+            globalStore.ocr.windowPinned = value;
+          }}
+          title={t("preference.ocr.behavior_settings.label.window_pinned")}
+          value={ocr.windowPinned}
+        />
+
+        <ProSwitch
+          description={t(
+            "preference.ocr.behavior_settings.hints.hide_main_window",
+          )}
+          onChange={(value) => {
+            globalStore.ocr.hideMainWindow = value;
+          }}
+          title={t("preference.ocr.behavior_settings.label.hide_main_window")}
+          value={ocr.hideMainWindow}
+        />
+
+        <ProSwitch
+          description={t("preference.ocr.behavior_settings.hints.save_history")}
+          onChange={(value) => {
+            globalStore.ocr.saveHistory = value;
+          }}
+          title={t("preference.ocr.behavior_settings.label.save_history")}
+          value={ocr.saveHistory}
         />
       </ProList>
     </>

--- a/src/pages/Preference/components/OCR/index.tsx
+++ b/src/pages/Preference/components/OCR/index.tsx
@@ -1,0 +1,182 @@
+import { Input, Select } from "antd";
+import { useTranslation } from "react-i18next";
+import { useSnapshot } from "valtio";
+import ProList from "@/components/ProList";
+import ProListItem from "@/components/ProListItem";
+import ProShortcut from "@/components/ProShortcut";
+import ProSwitch from "@/components/ProSwitch";
+import { globalStore } from "@/stores/global";
+
+const LANGUAGE_OPTIONS = [
+  { label: "简体中文", value: "zh-CN" },
+  { label: "繁體中文", value: "zh-TW" },
+  { label: "English", value: "en" },
+  { label: "日本語", value: "ja" },
+  { label: "한국어", value: "ko" },
+  { label: "Français", value: "fr" },
+  { label: "Deutsch", value: "de" },
+  { label: "Español", value: "es" },
+  { label: "Русский", value: "ru" },
+];
+
+const OCRSettings = () => {
+  const { ocr, shortcut } = useSnapshot(globalStore);
+  const { t } = useTranslation();
+
+  return (
+    <>
+      <ProList header={t("preference.ocr.api_settings.title")}>
+        <ProListItem
+          description={t("preference.ocr.api_settings.hints.api_base")}
+          title={t("preference.ocr.api_settings.label.api_base")}
+        >
+          <Input
+            onChange={(e) => {
+              globalStore.ocr.apiBase = e.target.value;
+            }}
+            placeholder="https://api.openai.com"
+            style={{ width: 240 }}
+            value={ocr.apiBase}
+          />
+        </ProListItem>
+
+        <ProListItem
+          description={t("preference.ocr.api_settings.hints.api_key")}
+          title={t("preference.ocr.api_settings.label.api_key")}
+        >
+          <Input.Password
+            onChange={(e) => {
+              globalStore.ocr.apiKey = e.target.value;
+            }}
+            placeholder="sk-..."
+            style={{ width: 240 }}
+            value={ocr.apiKey}
+          />
+        </ProListItem>
+
+        <ProListItem
+          description={t("preference.ocr.api_settings.hints.model")}
+          title={t("preference.ocr.api_settings.label.model")}
+        >
+          <Input
+            onChange={(e) => {
+              globalStore.ocr.model = e.target.value;
+            }}
+            placeholder="gpt-4o"
+            style={{ width: 240 }}
+            value={ocr.model}
+          />
+        </ProListItem>
+      </ProList>
+
+      <ProList header={t("preference.ocr.translate_settings.title")}>
+        <ProSwitch
+          onChange={(value) => {
+            globalStore.ocr.translate.enabled = value;
+          }}
+          title={t("preference.ocr.translate_settings.label.enabled")}
+          value={ocr.translate.enabled}
+        />
+
+        <ProListItem
+          description={t(
+            "preference.ocr.translate_settings.hints.target_language",
+          )}
+          title={t("preference.ocr.translate_settings.label.target_language")}
+        >
+          <Select
+            onChange={(value) => {
+              globalStore.ocr.translate.targetLanguage = value;
+            }}
+            options={LANGUAGE_OPTIONS}
+            style={{ width: 150 }}
+            value={ocr.translate.targetLanguage}
+          />
+        </ProListItem>
+
+        <ProListItem
+          description={t("preference.ocr.translate_settings.hints.api_base")}
+          title={t("preference.ocr.translate_settings.label.api_base")}
+        >
+          <Input
+            onChange={(e) => {
+              globalStore.ocr.translate.apiBase = e.target.value;
+            }}
+            placeholder={t(
+              "preference.ocr.translate_settings.placeholder.api_base",
+            )}
+            style={{ width: 240 }}
+            value={ocr.translate.apiBase}
+          />
+        </ProListItem>
+
+        <ProListItem
+          description={t("preference.ocr.translate_settings.hints.api_key")}
+          title={t("preference.ocr.translate_settings.label.api_key")}
+        >
+          <Input.Password
+            onChange={(e) => {
+              globalStore.ocr.translate.apiKey = e.target.value;
+            }}
+            placeholder={t(
+              "preference.ocr.translate_settings.placeholder.api_key",
+            )}
+            style={{ width: 240 }}
+            value={ocr.translate.apiKey}
+          />
+        </ProListItem>
+
+        <ProListItem
+          description={t("preference.ocr.translate_settings.hints.model")}
+          title={t("preference.ocr.translate_settings.label.model")}
+        >
+          <Input
+            onChange={(e) => {
+              globalStore.ocr.translate.model = e.target.value;
+            }}
+            placeholder={t(
+              "preference.ocr.translate_settings.placeholder.model",
+            )}
+            style={{ width: 240 }}
+            value={ocr.translate.model}
+          />
+        </ProListItem>
+      </ProList>
+
+      <ProList header={t("preference.ocr.shortcut_settings.title")}>
+        <ProShortcut
+          description={t("preference.ocr.shortcut_settings.hints.ocr")}
+          onChange={(value) => {
+            globalStore.shortcut.ocr = value;
+          }}
+          title={t("preference.ocr.shortcut_settings.label.ocr")}
+          value={shortcut.ocr}
+        />
+
+        <ProShortcut
+          description={t(
+            "preference.ocr.shortcut_settings.hints.ocr_translate",
+          )}
+          onChange={(value) => {
+            globalStore.shortcut.ocrTranslate = value;
+          }}
+          title={t("preference.ocr.shortcut_settings.label.ocr_translate")}
+          value={shortcut.ocrTranslate}
+        />
+      </ProList>
+
+      <ProList header={t("preference.ocr.behavior_settings.title")}>
+        <ProSwitch
+          description={t("preference.ocr.behavior_settings.hints.auto_copy")}
+          onChange={(value) => {
+            globalStore.ocr.autoCopy = value;
+          }}
+          title={t("preference.ocr.behavior_settings.label.auto_copy")}
+          value={ocr.autoCopy}
+        />
+      </ProList>
+    </>
+  );
+};
+
+export default OCRSettings;

--- a/src/pages/Preference/index.tsx
+++ b/src/pages/Preference/index.tsx
@@ -53,6 +53,18 @@ const Preference = () => {
   // 监听快捷键切换窗口显隐
   useRegister(toggleWindowVisible, [shortcut.preference]);
 
+  // 监听 OCR 快捷键
+  useRegister(async () => {
+    const { ocrFromClipboard } = await import("@/plugins/ocr");
+    await ocrFromClipboard(false);
+  }, [shortcut.ocr]);
+
+  // 监听 OCR+翻译 快捷键
+  useRegister(async () => {
+    const { ocrFromClipboard } = await import("@/plugins/ocr");
+    await ocrFromClipboard(true);
+  }, [shortcut.ocrTranslate]);
+
   // 配置项变化通知其它窗口和本地存储
   const handleStoreChanged = () => {
     emit(LISTEN_KEY.STORE_CHANGED, { clipboardStore, globalStore });

--- a/src/pages/Preference/index.tsx
+++ b/src/pages/Preference/index.tsx
@@ -23,6 +23,7 @@ import About from "./components/About";
 import Clipboard from "./components/Clipboard";
 import General from "./components/General";
 import History from "./components/History";
+import OCR from "./components/OCR";
 import Shortcut from "./components/Shortcut";
 
 const Preference = () => {
@@ -84,6 +85,12 @@ const Preference = () => {
         icon: "i-lucide:keyboard",
         key: "shortcut",
         label: t("preference.menu.title.shortcut"),
+      },
+      {
+        content: <OCR />,
+        icon: "i-lucide:scan-text",
+        key: "ocr",
+        label: t("preference.menu.title.ocr"),
       },
       // {
       //   content: <Backup />,

--- a/src/plugins/ocr.ts
+++ b/src/plugins/ocr.ts
@@ -1,0 +1,159 @@
+import { emit } from "@tauri-apps/api/event";
+import { WebviewWindow } from "@tauri-apps/api/webviewWindow";
+import { open } from "@tauri-apps/plugin-dialog";
+import { readFile } from "@tauri-apps/plugin-fs";
+import { error, info } from "@tauri-apps/plugin-log";
+import { LISTEN_KEY, WINDOW_LABEL } from "@/constants";
+import { globalStore } from "@/stores/global";
+
+/**
+ * 显示 OCR 窗口
+ */
+export const showOcrWindow = async () => {
+  try {
+    const ocrWindow = await WebviewWindow.getByLabel(WINDOW_LABEL.OCR);
+
+    if (ocrWindow) {
+      await ocrWindow.show();
+      await ocrWindow.setFocus();
+    } else {
+      // 如果窗口不存在，创建新窗口
+      const webview = new WebviewWindow(WINDOW_LABEL.OCR, {
+        alwaysOnTop: true,
+        center: true,
+        decorations: false,
+        height: 500,
+        minHeight: 300,
+        minWidth: 400,
+        resizable: true,
+        skipTaskbar: true,
+        title: "OCR",
+        transparent: true,
+        url: "index.html/#/ocr",
+        width: 450,
+      });
+
+      webview.once("tauri://created", () => {
+        info("OCR window created");
+      });
+    }
+  } catch (err) {
+    error(`Failed to show OCR window: ${err}`);
+  }
+};
+
+/**
+ * 隐藏 OCR 窗口
+ */
+export const hideOcrWindow = async () => {
+  try {
+    const ocrWindow = await WebviewWindow.getByLabel(WINDOW_LABEL.OCR);
+
+    if (ocrWindow) {
+      await ocrWindow.hide();
+    }
+  } catch (err) {
+    error(`Failed to hide OCR window: ${err}`);
+  }
+};
+
+/**
+ * 从文件选择图片并进行 OCR
+ */
+export const selectImageForOcr = async (withTranslate: boolean) => {
+  const selected = await open({
+    filters: [
+      {
+        extensions: ["png", "jpg", "jpeg", "gif", "bmp", "webp"],
+        name: "Images",
+      },
+    ],
+    multiple: false,
+  });
+
+  if (selected) {
+    const filePath = typeof selected === "string" ? selected : selected;
+    await processImageFile(filePath, withTranslate);
+  }
+};
+
+/**
+ * 处理图片文件
+ */
+export const processImageFile = async (
+  filePath: string,
+  withTranslate: boolean,
+) => {
+  try {
+    // 读取文件为 base64
+    const fileData = await readFile(filePath);
+    const base64 = arrayBufferToBase64(fileData);
+
+    // 显示 OCR 窗口
+    await showOcrWindow();
+
+    // 发送 OCR 开始事件
+    await emit(LISTEN_KEY.OCR_START, {
+      imageBase64: base64,
+      withTranslate,
+    });
+  } catch (err) {
+    error(`Failed to process image: ${err}`);
+  }
+};
+
+/**
+ * 从剪贴板获取图片并进行 OCR
+ */
+export const ocrFromClipboard = async (withTranslate: boolean) => {
+  try {
+    // 使用 clipboard-x 插件读取剪贴板图片
+    const { readImage } = await import("tauri-plugin-clipboard-x-api");
+    const imageBase64 = await readImage();
+
+    if (imageBase64) {
+      // 显示 OCR 窗口
+      await showOcrWindow();
+
+      // 发送 OCR 开始事件
+      await emit(LISTEN_KEY.OCR_START, {
+        imageBase64,
+        withTranslate,
+      });
+    }
+  } catch (err) {
+    error(`Failed to read clipboard image: ${err}`);
+  }
+};
+
+/**
+ * 触发系统截图工具
+ * Windows: Win + Shift + S
+ * macOS: Cmd + Shift + 4
+ * Linux: 使用 gnome-screenshot 或其他工具
+ */
+export const triggerScreenshot = async (withTranslate: boolean) => {
+  // 隐藏主窗口（如果设置了）
+  if (globalStore.ocr.hideMainWindow) {
+    const { hideWindow } = await import("./window");
+    await hideWindow();
+  }
+
+  // 延时等待用户完成截图
+  await new Promise((resolve) => setTimeout(resolve, 500));
+
+  // 从剪贴板读取图片
+  await ocrFromClipboard(withTranslate);
+};
+
+/**
+ * 将 ArrayBuffer 转换为 Base64
+ */
+const arrayBufferToBase64 = (buffer: Uint8Array): string => {
+  let binary = "";
+  const bytes = new Uint8Array(buffer);
+  for (let i = 0; i < bytes.byteLength; i++) {
+    binary += String.fromCharCode(bytes[i]);
+  }
+  return btoa(binary);
+};

--- a/src/plugins/window.ts
+++ b/src/plugins/window.ts
@@ -56,6 +56,11 @@ export const toggleWindowVisible = async () => {
       await emit(LISTEN_KEY.ACTIVATE_BACK_TOP);
     }
 
+    // 激活时切换至全部分组
+    if (window.showAll) {
+      await emit(LISTEN_KEY.ACTIVATE_SHOW_ALL);
+    }
+
     if (window.style === "standard" && window.position !== "remember") {
       const monitor = await getCursorMonitor();
 

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -1,5 +1,6 @@
 import { createHashRouter } from "react-router-dom";
 import Main from "@/pages/Main";
+import OCR from "@/pages/OCR";
 import Preference from "@/pages/Preference";
 
 export const router = createHashRouter([
@@ -10,5 +11,9 @@ export const router = createHashRouter([
   {
     Component: Preference,
     path: "/preference",
+  },
+  {
+    Component: OCR,
+    path: "/ocr",
   },
 ]);

--- a/src/services/ocr/openai.ts
+++ b/src/services/ocr/openai.ts
@@ -4,6 +4,7 @@ export interface OcrConfig {
   apiBase: string;
   apiKey: string;
   model: string;
+  prompt: string;
 }
 
 export interface OcrResult {
@@ -19,7 +20,7 @@ export async function performOcr(
   imageBase64: string,
   config: OcrConfig,
 ): Promise<OcrResult> {
-  const { apiBase, apiKey, model } = config;
+  const { apiBase, apiKey, model, prompt } = config;
 
   if (!apiKey) {
     return {
@@ -43,7 +44,7 @@ export async function performOcr(
           {
             content: [
               {
-                text: "请识别图片中的所有文字，只输出识别到的文字内容，不要添加任何解释、格式或标点符号修改。如果图片中没有文字，请回复[无文字]。",
+                text: prompt,
                 type: "text",
               },
               {

--- a/src/services/ocr/openai.ts
+++ b/src/services/ocr/openai.ts
@@ -1,0 +1,98 @@
+import { fetch } from "@tauri-apps/plugin-http";
+
+export interface OcrConfig {
+  apiBase: string;
+  apiKey: string;
+  model: string;
+}
+
+export interface OcrResult {
+  success: boolean;
+  text: string;
+  error?: string;
+}
+
+/**
+ * 使用 OpenAI 兼容 API 进行 OCR 识别
+ */
+export async function performOcr(
+  imageBase64: string,
+  config: OcrConfig,
+): Promise<OcrResult> {
+  const { apiBase, apiKey, model } = config;
+
+  if (!apiKey) {
+    return {
+      error: "API Key is not configured",
+      success: false,
+      text: "",
+    };
+  }
+
+  // 构建 API URL
+  let url = apiBase.replace(/\/$/, "");
+  if (!url.endsWith("/chat/completions")) {
+    url = `${url}/v1/chat/completions`;
+  }
+
+  try {
+    const response = await fetch(url, {
+      body: JSON.stringify({
+        max_tokens: 4096,
+        messages: [
+          {
+            content: [
+              {
+                text: "请识别图片中的所有文字，只输出识别到的文字内容，不要添加任何解释、格式或标点符号修改。如果图片中没有文字，请回复[无文字]。",
+                type: "text",
+              },
+              {
+                image_url: {
+                  url: `data:image/png;base64,${imageBase64}`,
+                },
+                type: "image_url",
+              },
+            ],
+            role: "user",
+          },
+        ],
+        model,
+      }),
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        "Content-Type": "application/json",
+      },
+      method: "POST",
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      return {
+        error: `API Error (${response.status}): ${errorText}`,
+        success: false,
+        text: "",
+      };
+    }
+
+    const data = (await response.json()) as {
+      choices: Array<{
+        message: {
+          content: string;
+        };
+      }>;
+    };
+
+    const text = data.choices[0]?.message?.content?.trim() || "";
+
+    return {
+      success: true,
+      text,
+    };
+  } catch (error) {
+    return {
+      error: `Request failed: ${error}`,
+      success: false,
+      text: "",
+    };
+  }
+}

--- a/src/services/translate/openai.ts
+++ b/src/services/translate/openai.ts
@@ -1,0 +1,99 @@
+import { fetch } from "@tauri-apps/plugin-http";
+
+export interface TranslateConfig {
+  apiBase: string;
+  apiKey: string;
+  model: string;
+  targetLanguage: string;
+}
+
+export interface TranslateResult {
+  success: boolean;
+  text: string;
+  error?: string;
+}
+
+/**
+ * 使用 OpenAI 兼容 API 进行翻译
+ */
+export async function translate(
+  text: string,
+  config: TranslateConfig,
+): Promise<TranslateResult> {
+  const { apiBase, apiKey, model, targetLanguage } = config;
+
+  if (!apiKey) {
+    return {
+      error: "API Key is not configured",
+      success: false,
+      text: "",
+    };
+  }
+
+  if (!text.trim()) {
+    return {
+      error: "No text to translate",
+      success: false,
+      text: "",
+    };
+  }
+
+  // 构建 API URL
+  let url = apiBase.replace(/\/$/, "");
+  if (!url.endsWith("/chat/completions")) {
+    url = `${url}/v1/chat/completions`;
+  }
+
+  try {
+    const response = await fetch(url, {
+      body: JSON.stringify({
+        messages: [
+          {
+            content: `You are a professional translator. Translate the following text to ${targetLanguage}. Only output the translation result, without any explanations, notes, or the original text.`,
+            role: "system",
+          },
+          {
+            content: text,
+            role: "user",
+          },
+        ],
+        model,
+      }),
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        "Content-Type": "application/json",
+      },
+      method: "POST",
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      return {
+        error: `API Error (${response.status}): ${errorText}`,
+        success: false,
+        text: "",
+      };
+    }
+
+    const data = (await response.json()) as {
+      choices: Array<{
+        message: {
+          content: string;
+        };
+      }>;
+    };
+
+    const translatedText = data.choices[0]?.message?.content?.trim() || "";
+
+    return {
+      success: true,
+      text: translatedText,
+    };
+  } catch (error) {
+    return {
+      error: `Request failed: ${error}`,
+      success: false,
+      text: "",
+    };
+  }
+}

--- a/src/services/translate/openai.ts
+++ b/src/services/translate/openai.ts
@@ -5,6 +5,7 @@ export interface TranslateConfig {
   apiKey: string;
   model: string;
   targetLanguage: string;
+  systemPrompt: string;
 }
 
 export interface TranslateResult {
@@ -20,7 +21,7 @@ export async function translate(
   text: string,
   config: TranslateConfig,
 ): Promise<TranslateResult> {
-  const { apiBase, apiKey, model, targetLanguage } = config;
+  const { apiBase, apiKey, model, targetLanguage, systemPrompt } = config;
 
   if (!apiKey) {
     return {
@@ -44,12 +45,18 @@ export async function translate(
     url = `${url}/v1/chat/completions`;
   }
 
+  // 替换系统提示词中的变量
+  const processedPrompt = systemPrompt.replace(
+    /\$targetLanguage/g,
+    targetLanguage,
+  );
+
   try {
     const response = await fetch(url, {
       body: JSON.stringify({
         messages: [
           {
-            content: `You are a professional translator. Translate the following text to ${targetLanguage}. Only output the translation result, without any explanations, notes, or the original text.`,
+            content: processedPrompt,
             role: "system",
           },
           {

--- a/src/stores/global.ts
+++ b/src/stores/global.ts
@@ -16,8 +16,24 @@ export const globalStore = proxy<GlobalStore>({
 
   env: {},
 
+  ocr: {
+    apiBase: "https://api.openai.com",
+    apiKey: "",
+    autoCopy: true,
+    model: "gpt-4o",
+    translate: {
+      apiBase: "",
+      apiKey: "",
+      enabled: true,
+      model: "",
+      targetLanguage: "zh-CN",
+    },
+  },
+
   shortcut: {
     clipboard: "Alt+C",
+    ocr: "Alt+O",
+    ocrTranslate: "Alt+T",
     pastePlain: "",
     preference: "Alt+X",
     quickPaste: {

--- a/src/stores/global.ts
+++ b/src/stores/global.ts
@@ -20,14 +20,22 @@ export const globalStore = proxy<GlobalStore>({
     apiBase: "https://api.openai.com",
     apiKey: "",
     autoCopy: true,
+    autoSpeak: false,
+    hideMainWindow: true,
     model: "gpt-4o",
+    prompt:
+      "请识别图片中的所有文字，只输出识别到的文字内容，不要添加任何解释、格式或标点符号修改。如果图片中没有文字，请回复[无文字]。",
+    saveHistory: true,
     translate: {
       apiBase: "",
       apiKey: "",
       enabled: true,
       model: "",
+      systemPrompt:
+        "You are a professional translator. Translate the following text to $targetLanguage. Only output the translation result, without any explanations, notes, or the original text.",
       targetLanguage: "zh-CN",
     },
+    windowPinned: false,
   },
 
   shortcut: {

--- a/src/types/store.d.ts
+++ b/src/types/store.d.ts
@@ -45,17 +45,32 @@ export interface GlobalStore {
 
   // OCR 设置
   ocr: {
+    // API 配置
     apiBase: string;
     apiKey: string;
     model: string;
+    // OCR 提示词
+    prompt: string;
+    // 翻译配置
     translate: {
       enabled: boolean;
       apiBase: string;
       apiKey: string;
       model: string;
       targetLanguage: string;
+      // 翻译系统提示词
+      systemPrompt: string;
     };
+    // 行为设置
     autoCopy: boolean;
+    // 窗口设置
+    windowPinned: boolean;
+    // 自动朗读
+    autoSpeak: boolean;
+    // 保存历史
+    saveHistory: boolean;
+    // 截图后自动关闭主窗口
+    hideMainWindow: boolean;
   };
 
   // 只在当前系统环境使用

--- a/src/types/store.d.ts
+++ b/src/types/store.d.ts
@@ -39,6 +39,23 @@ export interface GlobalStore {
       value: string;
     };
     pastePlain: string;
+    ocr: string;
+    ocrTranslate: string;
+  };
+
+  // OCR 设置
+  ocr: {
+    apiBase: string;
+    apiKey: string;
+    model: string;
+    translate: {
+      enabled: boolean;
+      apiBase: string;
+      apiKey: string;
+      model: string;
+      targetLanguage: string;
+    };
+    autoCopy: boolean;
   };
 
   // 只在当前系统环境使用


### PR DESCRIPTION
## 问题描述 (Description)
修复了“激活时切换至全部分组”功能失效的问题。

虽然设置页面中存在该配置项，但底层的逻辑并未实现，导致窗口重新激活后仍保持在之前选择的分组。

## 修改内容 (Changes)
1. 在 [constants/index.ts](cci:7://file:///d:/ruanjian/EcoPaste/src/constants/index.ts:0:0-0:0) 中添加了 `ACTIVATE_SHOW_ALL` 事件常量。
2. 在 [plugins/window.ts](cci:7://file:///d:/ruanjian/EcoPaste/src/plugins/window.ts:0:0-0:0) 的 [toggleWindowVisible](cci:1://file:///d:/ruanjian/EcoPaste/src/plugins/window.ts:34:0-99:2) 函数中增加了对 `window.showAll` 设置项的判断，并在激活时发送事件。
3. 在 [pages/Main/index.tsx](cci:7://file:///d:/ruanjian/EcoPaste/src/pages/Main/index.tsx:0:0-0:0) 中增加了对 `ACTIVATE_SHOW_ALL` 事件的监听，将 `rootState.group` 重置为 `all`。

## 测试 (Test)
- 已通过 GitHub Actions 构建验证。
- 手动测试：开启设置后，切换到任意分组（如“文本”），隐藏窗口并重新激活，分组会自动恢复到“全部”。