### PR TITLE
perf: 列表查询截断 value 字段避免大文本拖慢渲染

### DIFF
--- a/src/database/history.ts
+++ b/src/database/history.ts
@@ -1,6 +1,6 @@
 import { exists, remove } from "@tauri-apps/plugin-fs";
 import type { AnyObject } from "antd/es/_util/type";
-import type { SelectQueryBuilder } from "kysely";
+import { type SelectQueryBuilder, sql } from "kysely";
 import { getDefaultSaveImagePath } from "tauri-plugin-clipboard-x-api";
 import type { DatabaseSchema, DatabaseSchemaHistory } from "@/types/database";
 import { join } from "@/utils/path";
@@ -8,18 +8,59 @@ import { getDatabase } from ".";
 
 type QueryBuilder = SelectQueryBuilder<DatabaseSchema, "history", AnyObject>;
 
+// 列表查询时 value 截断长度（只用于预览，避免几 MB 的文本拖慢渲染）
+const LIST_VALUE_TRUNCATE = 500;
+
+/**
+ * 查询历史记录（列表用，value 字段截断以提升性能）
+ */
 export const selectHistory = async (
   fn?: (qb: QueryBuilder) => QueryBuilder,
 ) => {
   const db = await getDatabase();
 
-  let qb = db.selectFrom("history").selectAll() as QueryBuilder;
+  // 不用 selectAll()，而是显式选择字段，value 截断到 500 字符
+  let qb = db
+    .selectFrom("history")
+    .select([
+      "id",
+      "type",
+      "group",
+      sql<string>`substr(value, 1, ${sql.lit(LIST_VALUE_TRUNCATE)})`.as(
+        "value",
+      ),
+      "search",
+      "count",
+      "width",
+      "height",
+      "favorite",
+      "createTime",
+      "note",
+      "subtype",
+    ]) as QueryBuilder;
 
   if (fn) {
     qb = fn(qb);
   }
 
   return qb.execute() as Promise<DatabaseSchemaHistory[]>;
+};
+
+/**
+ * 获取单条记录的完整 value（粘贴/导出/复制时用）
+ */
+export const getHistoryFullValue = async (
+  id: string,
+): Promise<string | undefined> => {
+  const db = await getDatabase();
+
+  const result = await db
+    .selectFrom("history")
+    .select("value")
+    .where("id", "=", id)
+    .executeTakeFirst();
+
+  return result?.value as string | undefined;
 };
 
 export const insertHistory = async (data: DatabaseSchemaHistory) => {

--- a/src/hooks/useContextMenu.ts
+++ b/src/hooks/useContextMenu.ts
@@ -6,7 +6,11 @@ import { find, isArray, remove } from "es-toolkit/compat";
 import { type MouseEvent, useContext } from "react";
 import { useTranslation } from "react-i18next";
 import { useSnapshot } from "valtio";
-import { deleteHistory, updateHistory } from "@/database/history";
+import {
+  deleteHistory,
+  getHistoryFullValue,
+  updateHistory,
+} from "@/database/history";
 import { MainContext } from "@/pages/Main";
 import type { ItemProps } from "@/pages/Main/components/HistoryList/components/Item";
 import { pasteToClipboard, writeToClipboard } from "@/plugins/clipboard";
@@ -57,11 +61,14 @@ export const useContextMenu = (props: UseContextMenuProps) => {
   const exportToFile = async () => {
     if (isArray(value)) return;
 
+    // 列表里的 value 可能被截断，导出时需要完整内容
+    const fullValue = (await getHistoryFullValue(id)) ?? value;
+
     const extname = type === "text" ? "txt" : type;
     const fileName = `${env.appName}_${id}.${extname}`;
     const path = join(await downloadDir(), fileName);
 
-    await writeTextFile(path, value);
+    await writeTextFile(path, fullValue);
 
     revealItemInDir(path);
   };

--- a/src/plugins/clipboard.ts
+++ b/src/plugins/clipboard.ts
@@ -6,6 +6,7 @@ import {
   writeRTF,
   writeText,
 } from "tauri-plugin-clipboard-x-api";
+import { getHistoryFullValue } from "@/database/history";
 import { clipboardStore } from "@/stores/clipboard";
 import type { DatabaseSchemaHistory } from "@/types/database";
 import { isColor, isEmail, isURL } from "@/utils/is";
@@ -33,20 +34,38 @@ export const getClipboardTextSubtype = async (value: string) => {
   }
 };
 
-export const writeToClipboard = (data: DatabaseSchemaHistory) => {
-  const { type, value, search } = data;
+/**
+ * 获取完整 value（列表里的 value 可能被截断，操作时需要完整内容）
+ */
+const resolveFullValue = async (data: DatabaseSchemaHistory) => {
+  const { id, type, value } = data;
+
+  // 图片类型的 value 是路径，不会被截断；files 类型在 useHistoryList 里已 parse
+  if (type === "image" || type === "files") return value;
+
+  // 文本类型：如果 value 看起来被截断了（等于 500 字符），从 DB 取完整值
+  if (typeof value === "string" && value.length === 500) {
+    return (await getHistoryFullValue(id)) ?? value;
+  }
+
+  return value;
+};
+
+export const writeToClipboard = async (data: DatabaseSchemaHistory) => {
+  const { type, search } = data;
+  const fullValue = await resolveFullValue(data);
 
   switch (type) {
     case "text":
-      return writeText(value);
+      return writeText(fullValue);
     case "rtf":
-      return writeRTF(search, value);
+      return writeRTF(search, fullValue);
     case "html":
-      return writeHTML(search, value);
+      return writeHTML(search, fullValue);
     case "image":
-      return writeImage(value);
+      return writeImage(fullValue);
     case "files":
-      return writeFiles(value);
+      return writeFiles(fullValue);
   }
 };
 
@@ -54,12 +73,14 @@ export const pasteToClipboard = async (
   data: DatabaseSchemaHistory,
   asPlain?: boolean,
 ) => {
-  const { type, value, search } = data;
+  const { type, search } = data;
   const { pastePlain } = clipboardStore.content;
 
   if (asPlain ?? pastePlain) {
     if (type === "files") {
-      await writeText(value.join("\n"));
+      const fullValue = await resolveFullValue(data);
+
+      await writeText(fullValue.join("\n"));
     } else {
       await writeText(search);
     }


### PR DESCRIPTION
## 概述

解决复制超大文本（如几 MB 的 base64 图片数据、60 万字的脚本）后，列表渲染严重卡顿的问题。

### 问题

当前 `selectHistory()` 使用 `selectAll()`（即 `SELECT *`），每条记录的完整 `value` 字段都会传到前端。但列表预览只显示前几行，完整内容是浪费的：

- 一条 280 万字符的 base64 文本 = 前端接收 **2.8 MB**
- 一页 20 条如果撞上几条大文本，一次性传 **4~5 MB**，导致渲染帧 400~600ms

### 改动

1. `selectHistory()`：`SELECT *` 改为显式选择字段，`value` 用 `substr(value, 1, 500)` 截断
2. 新增 `getHistoryFullValue(id)`：按 ID 单独查完整 value（粘贴/导出/复制时使用）
3. `writeToClipboard`/`pasteToClipboard`：自动检测截断并按需取完整值
4. 右键菜单「导出为文件」：同样使用完整值

### 效果

列表查询数据传输量减少 **99%+**（大文本场景），渲染帧时间显著下降。

相关 issues：#628