### PR TITLE
fix: 搜索防抖、防止旧结果覆盖新搜索、修复 Windows 假失焦

### DIFF
--- a/src/hooks/useHistoryList.ts
+++ b/src/hooks/useHistoryList.ts
@@ -23,15 +23,23 @@ export const useHistoryList = (options: Options) => {
     noMore: false,
     page: 1,
     size: 20,
+    // 防止旧请求结果覆盖新搜索
+    fetchId: 0,
+    queryKey: "",
+    pendingReload: false,
   });
 
-  const fetchData = async () => {
-    try {
-      if (state.loading) return;
+  const getQueryKey = () => {
+    const { group, search } = rootState;
 
+    return JSON.stringify([group, search ?? ""]);
+  };
+
+  const fetchData = async (key: string, page: number) => {
+    try {
       state.loading = true;
 
-      const { page } = state;
+      const currentFetchId = ++state.fetchId;
 
       const list = await selectHistory((qb) => {
         const { size } = state;
@@ -54,6 +62,10 @@ export const useHistoryList = (options: Options) => {
           .limit(size)
           .orderBy("createTime", "desc");
       });
+
+      // 丢弃过期请求的结果，避免旧结果覆盖新搜索
+      if (currentFetchId !== state.fetchId) return;
+      if (key !== state.queryKey) return;
 
       for (const item of list) {
         const { type, value } = item;
@@ -91,22 +103,41 @@ export const useHistoryList = (options: Options) => {
       rootState.list = unionBy(rootState.list, list, "id");
     } finally {
       state.loading = false;
+
+      if (state.pendingReload) {
+        state.pendingReload = false;
+        reload();
+      }
     }
   };
 
   const reload = () => {
+    const key = getQueryKey();
+
+    state.queryKey = key;
     state.page = 1;
     state.noMore = false;
 
-    return fetchData();
+    rootState.list = [];
+    rootState.activeId = void 0;
+
+    if (state.loading) {
+      state.pendingReload = true;
+      return;
+    }
+
+    return fetchData(key, 1);
   };
 
   const loadMore = () => {
     if (state.noMore) return;
+    if (state.loading) return;
 
-    state.page += 1;
+    const nextPage = state.page + 1;
 
-    fetchData();
+    state.page = nextPage;
+
+    fetchData(state.queryKey || getQueryKey(), nextPage);
   };
 
   useTauriListen(LISTEN_KEY.REFRESH_CLIPBOARD_LIST, reload);

--- a/src/hooks/useTauriFocus.ts
+++ b/src/hooks/useTauriFocus.ts
@@ -18,16 +18,23 @@ export const useTauriFocus = (props: Props) => {
 
     const wait = isMac ? 0 : 100;
 
-    const debounced = debounce(({ payload }) => {
-      if (payload) {
+    // Windows 上偶尔会收到“假失焦”事件，这里用 isFocused 二次确认
+    const debounced = debounce(async () => {
+      const focused = await appWindow.isFocused();
+
+      if (focused) {
         onFocus?.();
       } else {
         onBlur?.();
       }
     }, wait);
 
-    unlistenRef.current = await appWindow.onFocusChanged(debounced);
+    unlistenRef.current = await appWindow.onFocusChanged(() => {
+      void debounced();
+    });
   });
 
-  useUnmount(unlistenRef.current);
+  useUnmount(() => {
+    unlistenRef.current?.();
+  });
 };

--- a/src/pages/Main/components/SearchInput/index.tsx
+++ b/src/pages/Main/components/SearchInput/index.tsx
@@ -26,7 +26,14 @@ const SearchInput: FC<HTMLAttributes<HTMLDivElement>> = (props) => {
   useEffect(() => {
     if (isComposition) return;
 
-    rootState.search = value;
+    // 搜索防抖：避免每个按键都触发一次查库
+    const timer = window.setTimeout(() => {
+      rootState.search = value;
+    }, 200);
+
+    return () => {
+      window.clearTimeout(timer);
+    };
   }, [value, isComposition]);
 
   useTauriFocus({


### PR DESCRIPTION
## 概述

修复搜索历史记录时的三个问题：频繁查库卡顿、旧搜索结果覆盖新搜索、Windows 上假失焦导致窗口消失/搜索框清空。

### 问题 1：搜索无防抖

每个按键都立即触发一次数据库查询，快速输入时造成多次无意义的全表扫描。

**修复**：SearchInput 添加 200ms 防抖。

### 问题 2：旧搜索结果覆盖新搜索

用户快速输入时，先发出的查询可能晚于后发的查询返回，导致列表显示旧结果（视觉上"搜索回退"）。

**修复**：
- 添加 `fetchId` 机制，每次查询递增 ID，返回时比对是否仍是最新请求
- 添加 `queryKey` 比对，确保结果对应当前搜索条件
- 添加 `pendingReload`，查询中途触发新搜索时自动接力

### 问题 3：Windows 假失焦

Windows 上 `onFocusChanged` 偶尔会发出错误的失焦事件，触发 `hideWindow()` 隐藏窗口和 `autoClear` 清空搜索框。

**修复**：`useTauriFocus` 在收到失焦事件后，用 `appWindow.isFocused()` 二次确认，减少误触发。

相关 issues：#524 #882 #966