### PR TITLE
perf: 启用 WAL 模式并添加 B-Tree 索引以加速查询

### DIFF
--- a/src/database/index.ts
+++ b/src/database/index.ts
@@ -1,6 +1,6 @@
 import Database from "@tauri-apps/plugin-sql";
 import { isBoolean } from "es-toolkit";
-import { Kysely } from "kysely";
+import { Kysely, sql } from "kysely";
 import { TauriSqliteDialect } from "kysely-dialect-tauri";
 import { SerializePlugin } from "kysely-plugin-serialize";
 import type { DatabaseSchema } from "@/types/database";
@@ -31,6 +31,9 @@ export const getDatabase = async () => {
     ],
   });
 
+  // 启用 WAL 模式：读写并发，搜索时不阻塞剪贴板写入
+  await sql`PRAGMA journal_mode = WAL`.execute(db);
+
   await db.schema
     .createTable("history")
     .ifNotExists()
@@ -46,6 +49,28 @@ export const getDatabase = async () => {
     .addColumn("createTime", "text")
     .addColumn("note", "text")
     .addColumn("subtype", "text")
+    .execute();
+
+  // B-Tree 索引：提升 ORDER BY createTime DESC LIMIT 的性能
+  await db.schema
+    .createIndex("idx_history_createTime")
+    .ifNotExists()
+    .on("history")
+    .column("createTime")
+    .execute();
+
+  await db.schema
+    .createIndex("idx_history_group_createTime")
+    .ifNotExists()
+    .on("history")
+    .columns(["group", "createTime"])
+    .execute();
+
+  await db.schema
+    .createIndex("idx_history_favorite_createTime")
+    .ifNotExists()
+    .on("history")
+    .columns(["favorite", "createTime"])
     .execute();
 
   return db;


### PR DESCRIPTION
## 概述

为大数据量用户优化查询性能。

### 改动

1. **WAL 模式**：`PRAGMA journal_mode = WAL`，读写并发，搜索时不阻塞剪贴板写入
2. **B-Tree 索引**：
   - `idx_history_createTime`：加速 `ORDER BY createTime DESC LIMIT` 分页查询
   - `idx_history_group_createTime`：加速按分组筛选 + 排序
   - `idx_history_favorite_createTime`：加速收藏筛选 + 排序

配合现有的分页查询（`LIMIT 20`），索引可以让 SQLite 沿索引顺序扫描并提前终止，减少不必要的全表扫描。

### 无副作用

- 索引使用 `IF NOT EXISTS`，对已有数据库安全
- WAL 模式是 SQLite 推荐的并发模式，无兼容性风险
- 不改变任何查询逻辑，仅提供索引加速

相关 issues：#467