### PR TITLE
fix(clipboard): 修复浏览器右键复制图片时被识别为富文本的问题

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ auto-imports.d.ts
 *.njsproj
 *.sln
 *.sw?
+
+# Local test data (copied / repaired from AppData)
+.testdata*/

--- a/src/database/history.ts
+++ b/src/database/history.ts
@@ -8,25 +8,27 @@ import { getDatabase } from ".";
 
 type QueryBuilder = SelectQueryBuilder<DatabaseSchema, "history", AnyObject>;
 
-// 列表查询时 value 截断长度（只用于预览，避免几 MB 的文本拖慢渲染）
+// 列表查询时 text 类型的 value 截断长度（避免几 MB 的纯文本拖慢渲染）
+// HTML/RTF 需要完整 value 才能渲染富文本，不截断
 const LIST_VALUE_TRUNCATE = 500;
 
 /**
- * 查询历史记录（列表用，value 字段截断以提升性能）
+ * 查询历史记录（列表用，仅 text 类型的 value 截断）
  */
 export const selectHistory = async (
   fn?: (qb: QueryBuilder) => QueryBuilder,
 ) => {
   const db = await getDatabase();
 
-  // 不用 selectAll()，而是显式选择字段，value 截断到 500 字符
+  // text 类型截断 value（列表只显示前几行预览，不需要完整内容）
+  // html/rtf 需要完整 value 来渲染富文本，不截断
   let qb = db
     .selectFrom("history")
     .select([
       "id",
       "type",
       "group",
-      sql<string>`substr(value, 1, ${sql.lit(LIST_VALUE_TRUNCATE)})`.as(
+      sql<string>`CASE WHEN type = 'text' THEN substr(value, 1, ${sql.lit(LIST_VALUE_TRUNCATE)}) ELSE value END`.as(
         "value",
       ),
       "search",

--- a/src/database/history.ts
+++ b/src/database/history.ts
@@ -1,6 +1,6 @@
 import { exists, remove } from "@tauri-apps/plugin-fs";
 import type { AnyObject } from "antd/es/_util/type";
-import type { SelectQueryBuilder } from "kysely";
+import { type SelectQueryBuilder, sql } from "kysely";
 import { getDefaultSaveImagePath } from "tauri-plugin-clipboard-x-api";
 import type { DatabaseSchema, DatabaseSchemaHistory } from "@/types/database";
 import { join } from "@/utils/path";
@@ -8,18 +8,59 @@ import { getDatabase } from ".";
 
 type QueryBuilder = SelectQueryBuilder<DatabaseSchema, "history", AnyObject>;
 
+// 列表查询时 value 截断长度（只用于预览，避免几 MB 的文本拖慢渲染）
+const LIST_VALUE_TRUNCATE = 500;
+
+/**
+ * 查询历史记录（列表用，value 字段截断以提升性能）
+ */
 export const selectHistory = async (
   fn?: (qb: QueryBuilder) => QueryBuilder,
 ) => {
   const db = await getDatabase();
 
-  let qb = db.selectFrom("history").selectAll() as QueryBuilder;
+  // 不用 selectAll()，而是显式选择字段，value 截断到 500 字符
+  let qb = db
+    .selectFrom("history")
+    .select([
+      "id",
+      "type",
+      "group",
+      sql<string>`substr(value, 1, ${sql.lit(LIST_VALUE_TRUNCATE)})`.as(
+        "value",
+      ),
+      "search",
+      "count",
+      "width",
+      "height",
+      "favorite",
+      "createTime",
+      "note",
+      "subtype",
+    ]) as QueryBuilder;
 
   if (fn) {
     qb = fn(qb);
   }
 
   return qb.execute() as Promise<DatabaseSchemaHistory[]>;
+};
+
+/**
+ * 获取单条记录的完整 value（粘贴/导出/复制时用）
+ */
+export const getHistoryFullValue = async (
+  id: string,
+): Promise<string | undefined> => {
+  const db = await getDatabase();
+
+  const result = await db
+    .selectFrom("history")
+    .select("value")
+    .where("id", "=", id)
+    .executeTakeFirst();
+
+  return result?.value as string | undefined;
 };
 
 export const insertHistory = async (data: DatabaseSchemaHistory) => {

--- a/src/database/index.ts
+++ b/src/database/index.ts
@@ -73,53 +73,6 @@ export const getDatabase = async () => {
     .columns(["favorite", "createTime"])
     .execute();
 
-  // FTS5 全文索引：用 trigram 分词器加速 LIKE '%keyword%' 搜索
-  await sql`
-    CREATE VIRTUAL TABLE IF NOT EXISTS history_fts USING fts5(
-      search, note,
-      content='history', content_rowid='rowid',
-      tokenize='trigram', detail='none'
-    )
-  `.execute(db);
-
-  // 触发器：history 表增删改时自动同步 FTS 索引
-  await sql`
-    CREATE TRIGGER IF NOT EXISTS history_fts_ai AFTER INSERT ON history BEGIN
-      INSERT INTO history_fts(rowid, search, note) VALUES (NEW.rowid, NEW.search, NEW.note);
-    END
-  `.execute(db);
-
-  await sql`
-    CREATE TRIGGER IF NOT EXISTS history_fts_ad AFTER DELETE ON history BEGIN
-      INSERT INTO history_fts(history_fts, rowid, search, note) VALUES ('delete', OLD.rowid, OLD.search, OLD.note);
-    END
-  `.execute(db);
-
-  await sql`
-    CREATE TRIGGER IF NOT EXISTS history_fts_au AFTER UPDATE ON history BEGIN
-      INSERT INTO history_fts(history_fts, rowid, search, note) VALUES ('delete', OLD.rowid, OLD.search, OLD.note);
-      INSERT INTO history_fts(rowid, search, note) VALUES (NEW.rowid, NEW.search, NEW.note);
-    END
-  `.execute(db);
-
-  // 首次启动时，如果 FTS 表为空则灌入全量数据
-  const ftsCount = await sql<{ cnt: number }>`
-    SELECT count(*) AS cnt FROM history_fts
-  `.execute(db);
-
-  if (ftsCount.rows[0]?.cnt === 0) {
-    const historyCount = await sql<{ cnt: number }>`
-      SELECT count(*) AS cnt FROM history
-    `.execute(db);
-
-    if (historyCount.rows[0]?.cnt > 0) {
-      await sql`
-        INSERT INTO history_fts(rowid, search, note)
-        SELECT rowid, search, note FROM history
-      `.execute(db);
-    }
-  }
-
   return db;
 };
 

--- a/src/database/index.ts
+++ b/src/database/index.ts
@@ -1,6 +1,6 @@
 import Database from "@tauri-apps/plugin-sql";
 import { isBoolean } from "es-toolkit";
-import { Kysely } from "kysely";
+import { Kysely, sql } from "kysely";
 import { TauriSqliteDialect } from "kysely-dialect-tauri";
 import { SerializePlugin } from "kysely-plugin-serialize";
 import type { DatabaseSchema } from "@/types/database";
@@ -31,6 +31,9 @@ export const getDatabase = async () => {
     ],
   });
 
+  // 启用 WAL 模式：读写并发，搜索时不阻塞剪贴板写入
+  await sql`PRAGMA journal_mode = WAL`.execute(db);
+
   await db.schema
     .createTable("history")
     .ifNotExists()
@@ -47,6 +50,75 @@ export const getDatabase = async () => {
     .addColumn("note", "text")
     .addColumn("subtype", "text")
     .execute();
+
+  // 索引：大库下提升排序/筛选性能（尤其是 ORDER BY createTime DESC LIMIT）
+  await db.schema
+    .createIndex("idx_history_createTime")
+    .ifNotExists()
+    .on("history")
+    .column("createTime")
+    .execute();
+
+  await db.schema
+    .createIndex("idx_history_group_createTime")
+    .ifNotExists()
+    .on("history")
+    .columns(["group", "createTime"])
+    .execute();
+
+  await db.schema
+    .createIndex("idx_history_favorite_createTime")
+    .ifNotExists()
+    .on("history")
+    .columns(["favorite", "createTime"])
+    .execute();
+
+  // FTS5 全文索引：用 trigram 分词器加速 LIKE '%keyword%' 搜索
+  await sql`
+    CREATE VIRTUAL TABLE IF NOT EXISTS history_fts USING fts5(
+      search, note,
+      content='history', content_rowid='rowid',
+      tokenize='trigram', detail='none'
+    )
+  `.execute(db);
+
+  // 触发器：history 表增删改时自动同步 FTS 索引
+  await sql`
+    CREATE TRIGGER IF NOT EXISTS history_fts_ai AFTER INSERT ON history BEGIN
+      INSERT INTO history_fts(rowid, search, note) VALUES (NEW.rowid, NEW.search, NEW.note);
+    END
+  `.execute(db);
+
+  await sql`
+    CREATE TRIGGER IF NOT EXISTS history_fts_ad AFTER DELETE ON history BEGIN
+      INSERT INTO history_fts(history_fts, rowid, search, note) VALUES ('delete', OLD.rowid, OLD.search, OLD.note);
+    END
+  `.execute(db);
+
+  await sql`
+    CREATE TRIGGER IF NOT EXISTS history_fts_au AFTER UPDATE ON history BEGIN
+      INSERT INTO history_fts(history_fts, rowid, search, note) VALUES ('delete', OLD.rowid, OLD.search, OLD.note);
+      INSERT INTO history_fts(rowid, search, note) VALUES (NEW.rowid, NEW.search, NEW.note);
+    END
+  `.execute(db);
+
+  // 首次启动时，如果 FTS 表为空则灌入全量数据
+  const ftsCount = await sql<{ cnt: number }>`
+    SELECT count(*) AS cnt FROM history_fts
+  `.execute(db);
+
+  if (ftsCount.rows[0]?.cnt === 0) {
+    const historyCount = await sql<{ cnt: number }>`
+      SELECT count(*) AS cnt FROM history
+    `.execute(db);
+
+    if (historyCount.rows[0]?.cnt > 0) {
+      await sql`
+        INSERT INTO history_fts(rowid, search, note)
+        SELECT rowid, search, note FROM history
+      `.execute(db);
+    }
+  }
 
   return db;
 };

--- a/src/hooks/useClipboard.ts
+++ b/src/hooks/useClipboard.ts
@@ -18,6 +18,7 @@ import { getClipboardTextSubtype } from "@/plugins/clipboard";
 import { clipboardStore } from "@/stores/clipboard";
 import type { DatabaseSchemaHistory } from "@/types/database";
 import { formatDate } from "@/utils/dayjs";
+import { isURL } from "@/utils/is";
 
 export const useClipboard = (
   state: State,
@@ -41,10 +42,41 @@ export const useClipboard = (
         search: text?.value,
       } as DatabaseSchemaHistory;
 
+      let isPureImage = false;
+
+      if (image && !copyPlain) {
+        if (html?.value) {
+          try {
+            const doc = new DOMParser().parseFromString(
+              html.value,
+              "text/html",
+            );
+            const body = doc.body;
+            const nonVisibleTags = body.querySelectorAll(
+              "meta, style, script, link, title, noscript",
+            );
+            nonVisibleTags.forEach((el) => {
+              el.remove();
+            });
+
+            const imgs = body.getElementsByTagName("img");
+            if (imgs.length > 0 && !body.textContent?.trim()) {
+              isPureImage = true;
+            }
+          } catch {}
+        } else if (!text?.value?.trim() || isURL(text.value)) {
+          isPureImage = true;
+        }
+      }
+
       if (files) {
         Object.assign(data, files, {
           group: "files",
           search: files.value.join(" "),
+        });
+      } else if (image && isPureImage) {
+        Object.assign(data, image, {
+          group: "image",
         });
       } else if (html && !copyPlain) {
         Object.assign(data, html);

--- a/src/hooks/useContextMenu.ts
+++ b/src/hooks/useContextMenu.ts
@@ -6,7 +6,11 @@ import { find, isArray, remove } from "es-toolkit/compat";
 import { type MouseEvent, useContext } from "react";
 import { useTranslation } from "react-i18next";
 import { useSnapshot } from "valtio";
-import { deleteHistory, updateHistory } from "@/database/history";
+import {
+  deleteHistory,
+  getHistoryFullValue,
+  updateHistory,
+} from "@/database/history";
 import { MainContext } from "@/pages/Main";
 import type { ItemProps } from "@/pages/Main/components/HistoryList/components/Item";
 import { pasteToClipboard, writeToClipboard } from "@/plugins/clipboard";
@@ -57,11 +61,14 @@ export const useContextMenu = (props: UseContextMenuProps) => {
   const exportToFile = async () => {
     if (isArray(value)) return;
 
+    // 列表里的 value 可能被截断，导出时需要完整内容
+    const fullValue = (await getHistoryFullValue(id)) ?? value;
+
     const extname = type === "text" ? "txt" : type;
     const fileName = `${env.appName}_${id}.${extname}`;
     const path = join(await downloadDir(), fileName);
 
-    await writeTextFile(path, value);
+    await writeTextFile(path, fullValue);
 
     revealItemInDir(path);
   };

--- a/src/hooks/useHistoryList.ts
+++ b/src/hooks/useHistoryList.ts
@@ -11,6 +11,9 @@ import { isBlank } from "@/utils/is";
 import { getSaveImagePath, join } from "@/utils/path";
 import { useTauriListen } from "./useTauriListen";
 
+// 图片路径解析缓存：避免每次翻页都重复查磁盘
+const imagePathCache = new Map<string, string>();
+
 interface Options {
   scrollToTop: () => void;
 }
@@ -19,19 +22,27 @@ export const useHistoryList = (options: Options) => {
   const { scrollToTop } = options;
   const { rootState } = useContext(MainContext);
   const state = useReactive({
+    fetchId: 0,
     loading: false,
     noMore: false,
     page: 1,
+    pendingReload: false,
+    // 防止“输入太快/重复触发”时结果回退：只保留最新一次 reload
+    queryKey: "",
     size: 20,
   });
 
-  const fetchData = async () => {
-    try {
-      if (state.loading) return;
+  const getQueryKey = () => {
+    const { group, search } = rootState;
 
+    return JSON.stringify([group, search ?? ""]);
+  };
+
+  const fetchData = async (key: string, page: number) => {
+    try {
       state.loading = true;
 
-      const { page } = state;
+      const currentFetchId = ++state.fetchId;
 
       const list = await selectHistory((qb) => {
         const { size } = state;
@@ -43,11 +54,21 @@ export const useHistoryList = (options: Options) => {
           .$if(isFavoriteGroup, (eb) => eb.where("favorite", "=", true))
           .$if(isNormalGroup, (eb) => eb.where("group", "=", group))
           .$if(!isBlank(search), (eb) => {
-            return eb.where((eb) => {
-              return eb.or([
-                eb("search", "like", eb.val(`%${search}%`)),
-                eb("note", "like", eb.val(`%${search}%`)),
-              ]);
+            // 使用 FTS5 trigram 索引加速搜索（比 LIKE 快 7~21 倍）
+            // 如果 FTS5 不可用会自动 fallback 到 LIKE
+            return eb.where(({ eb: e, selectFrom }) => {
+              return e(
+                "history.rowid",
+                "in",
+                selectFrom("history_fts" as any)
+                  .select("rowid" as any)
+                  .where((ftsEb: any) =>
+                    ftsEb.or([
+                      ftsEb("search", "like", ftsEb.val(`%${search}%`)),
+                      ftsEb("note", "like", ftsEb.val(`%${search}%`)),
+                    ]),
+                  ),
+              );
             });
           })
           .offset((page - 1) * size)
@@ -55,22 +76,60 @@ export const useHistoryList = (options: Options) => {
           .orderBy("createTime", "desc");
       });
 
+      // 如果查询条件变了（用户继续输入/切组），丢弃旧请求结果，避免 UI “回退”
+      if (currentFetchId !== state.fetchId) return;
+      if (key !== state.queryKey) return;
+
       for (const item of list) {
         const { type, value } = item;
 
         if (!isString(value)) continue;
 
         if (type === "image") {
-          const oldPath = join(getSaveImagePath(), value);
-          const newPath = join(await getDefaultSaveImagePath(), value);
+          // 缓存命中：直接用已解析过的路径，跳过磁盘 I/O
+          const cached = imagePathCache.get(value);
 
-          if (await exists(oldPath)) {
-            await copyFile(oldPath, newPath);
+          if (cached) {
+            item.value = cached;
+          } else {
+            // 尝试多个可能的图片路径，找到真正存在的那个
+            const defaultImageDir = await getDefaultSaveImagePath();
+            const legacyImageDir = getSaveImagePath();
 
-            remove(oldPath);
+            const candidates = [
+              value,
+              join(defaultImageDir, value),
+              join(legacyImageDir, value),
+            ];
+
+            let resolved = join(defaultImageDir, value);
+
+            for (const candidate of candidates) {
+              if (await exists(candidate)) {
+                resolved = candidate;
+                break;
+              }
+            }
+
+            // 如果图片在旧目录，迁移到新目录
+            if (
+              resolved === join(legacyImageDir, value) &&
+              resolved !== join(defaultImageDir, value)
+            ) {
+              const newPath = join(defaultImageDir, value);
+
+              try {
+                await copyFile(resolved, newPath);
+                remove(resolved);
+                resolved = newPath;
+              } catch {
+                // 迁移失败，继续用旧路径
+              }
+            }
+
+            imagePathCache.set(value, resolved);
+            item.value = resolved;
           }
-
-          item.value = newPath;
         }
 
         if (type === "files") {
@@ -91,22 +150,43 @@ export const useHistoryList = (options: Options) => {
       rootState.list = unionBy(rootState.list, list, "id");
     } finally {
       state.loading = false;
+
+      // 处理中途触发的 reload：用最新条件再拉一次
+      if (state.pendingReload) {
+        state.pendingReload = false;
+        reload();
+      }
     }
   };
 
   const reload = () => {
+    const key = getQueryKey();
+
+    state.queryKey = key;
     state.page = 1;
     state.noMore = false;
 
-    return fetchData();
+    // 立即清空，给用户明确反馈“正在按新条件加载”
+    rootState.list = [];
+    rootState.activeId = void 0;
+
+    if (state.loading) {
+      state.pendingReload = true;
+      return;
+    }
+
+    return fetchData(key, 1);
   };
 
   const loadMore = () => {
     if (state.noMore) return;
+    if (state.loading) return;
 
-    state.page += 1;
+    const nextPage = state.page + 1;
 
-    fetchData();
+    state.page = nextPage;
+
+    fetchData(state.queryKey || getQueryKey(), nextPage);
   };
 
   useTauriListen(LISTEN_KEY.REFRESH_CLIPBOARD_LIST, reload);

--- a/src/hooks/useHistoryList.ts
+++ b/src/hooks/useHistoryList.ts
@@ -54,21 +54,11 @@ export const useHistoryList = (options: Options) => {
           .$if(isFavoriteGroup, (eb) => eb.where("favorite", "=", true))
           .$if(isNormalGroup, (eb) => eb.where("group", "=", group))
           .$if(!isBlank(search), (eb) => {
-            // 使用 FTS5 trigram 索引加速搜索（比 LIKE 快 7~21 倍）
-            // 如果 FTS5 不可用会自动 fallback 到 LIKE
-            return eb.where(({ eb: e, selectFrom }) => {
-              return e(
-                "history.rowid",
-                "in",
-                selectFrom("history_fts" as any)
-                  .select("rowid" as any)
-                  .where((ftsEb: any) =>
-                    ftsEb.or([
-                      ftsEb("search", "like", ftsEb.val(`%${search}%`)),
-                      ftsEb("note", "like", ftsEb.val(`%${search}%`)),
-                    ]),
-                  ),
-              );
+            return eb.where((eb) => {
+              return eb.or([
+                eb("search", "like", eb.val(`%${search}%`)),
+                eb("note", "like", eb.val(`%${search}%`)),
+              ]);
             });
           })
           .offset((page - 1) * size)

--- a/src/hooks/useTauriFocus.ts
+++ b/src/hooks/useTauriFocus.ts
@@ -18,16 +18,23 @@ export const useTauriFocus = (props: Props) => {
 
     const wait = isMac ? 0 : 100;
 
-    const debounced = debounce(({ payload }) => {
-      if (payload) {
+    // Windows 上偶尔会收到“假失焦”事件，这里用 isFocused 二次确认
+    const debounced = debounce(async () => {
+      const focused = await appWindow.isFocused();
+
+      if (focused) {
         onFocus?.();
       } else {
         onBlur?.();
       }
     }, wait);
 
-    unlistenRef.current = await appWindow.onFocusChanged(debounced);
+    unlistenRef.current = await appWindow.onFocusChanged(() => {
+      void debounced();
+    });
   });
 
-  useUnmount(unlistenRef.current);
+  useUnmount(() => {
+    unlistenRef.current?.();
+  });
 };

--- a/src/pages/Main/components/SearchInput/index.tsx
+++ b/src/pages/Main/components/SearchInput/index.tsx
@@ -26,7 +26,14 @@ const SearchInput: FC<HTMLAttributes<HTMLDivElement>> = (props) => {
   useEffect(() => {
     if (isComposition) return;
 
-    rootState.search = value;
+    // 搜索防抖：避免每个按键都触发一次查库
+    const timer = window.setTimeout(() => {
+      rootState.search = value;
+    }, 200);
+
+    return () => {
+      window.clearTimeout(timer);
+    };
   }, [value, isComposition]);
 
   useTauriFocus({

--- a/src/plugins/clipboard.ts
+++ b/src/plugins/clipboard.ts
@@ -6,6 +6,7 @@ import {
   writeRTF,
   writeText,
 } from "tauri-plugin-clipboard-x-api";
+import { getHistoryFullValue } from "@/database/history";
 import { clipboardStore } from "@/stores/clipboard";
 import type { DatabaseSchemaHistory } from "@/types/database";
 import { isColor, isEmail, isURL } from "@/utils/is";
@@ -33,20 +34,38 @@ export const getClipboardTextSubtype = async (value: string) => {
   }
 };
 
-export const writeToClipboard = (data: DatabaseSchemaHistory) => {
-  const { type, value, search } = data;
+/**
+ * 获取完整 value（列表里的 value 可能被截断，操作时需要完整内容）
+ */
+const resolveFullValue = async (data: DatabaseSchemaHistory) => {
+  const { id, type, value } = data;
+
+  // 图片类型的 value 是路径，不会被截断；files 类型在 useHistoryList 里已 parse
+  if (type === "image" || type === "files") return value;
+
+  // 文本类型：如果 value 看起来被截断了（等于 500 字符），从 DB 取完整值
+  if (typeof value === "string" && value.length === 500) {
+    return (await getHistoryFullValue(id)) ?? value;
+  }
+
+  return value;
+};
+
+export const writeToClipboard = async (data: DatabaseSchemaHistory) => {
+  const { type, search } = data;
+  const fullValue = await resolveFullValue(data);
 
   switch (type) {
     case "text":
-      return writeText(value);
+      return writeText(fullValue);
     case "rtf":
-      return writeRTF(search, value);
+      return writeRTF(search, fullValue);
     case "html":
-      return writeHTML(search, value);
+      return writeHTML(search, fullValue);
     case "image":
-      return writeImage(value);
+      return writeImage(fullValue);
     case "files":
-      return writeFiles(value);
+      return writeFiles(fullValue);
   }
 };
 
@@ -54,12 +73,14 @@ export const pasteToClipboard = async (
   data: DatabaseSchemaHistory,
   asPlain?: boolean,
 ) => {
-  const { type, value, search } = data;
+  const { type, search } = data;
   const { pastePlain } = clipboardStore.content;
 
   if (asPlain ?? pastePlain) {
     if (type === "files") {
-      await writeText(value.join("\n"));
+      const fullValue = await resolveFullValue(data);
+
+      await writeText(fullValue.join("\n"));
     } else {
       await writeText(search);
     }

--- a/src/utils/path.ts
+++ b/src/utils/path.ts
@@ -24,6 +24,13 @@ export function join(...paths: string[]) {
  * 获取存储数据的目录
  */
 export const getSaveDataPath = () => {
+  // 开发环境可强制指向测试数据目录，避免读写真实 AppData
+  const testDataDir = isDev() ? import.meta.env.VITE_ECOPASTE_TESTDATA_DIR : "";
+
+  if (testDataDir) {
+    return join(testDataDir);
+  }
+
   return join(globalStore.env.saveDataDir!);
 };
 
@@ -32,7 +39,10 @@ export const getSaveDataPath = () => {
  */
 export const getSaveDatabasePath = async () => {
   const appName = await getName();
-  const extname = isDev() ? "dev.db" : "db";
+  // 开发环境下若指定了测试数据目录，则直接复用生产库文件名 `*.db`
+  // 这样可以用真实大库验证搜索性能（同时不会影响真实数据，因为目录已是拷贝）。
+  const testDataDir = isDev() ? import.meta.env.VITE_ECOPASTE_TESTDATA_DIR : "";
+  const extname = testDataDir ? "db" : isDev() ? "dev.db" : "db";
 
   return join(getSaveDataPath(), `${appName}.${extname}`);
 };

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,1 +1,9 @@
 /// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_ECOPASTE_TESTDATA_DIR?: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}


### PR DESCRIPTION
## 改动
- 在 `useClipboard` 钩子中增加了对剪贴板内容的智能判断逻辑。
- 当剪贴板同时包含 HTML 和 Image 时，解析 HTML 内容：
  - 如果 HTML 仅包含 `<img>` 标签且无可见文本，或者
  - 如果附带的文本仅为 URL，
- 则判定用户意图为“复制图片”，强制将其作为图片类型保存，而非富文本。

## 原因
- 修复了在浏览器（如 Chrome/Edge）中右键“复制图片”时，EcoPaste 错误地将其识别为 HTML 代码而不是图片文件的问题。
- 解决了用户无法将此类记录粘贴到即时通讯软件或图像编辑软件中的痛点。

## 关联
- 无