### PR TITLE
feat: 搜索框为空时支持左右方向键循环切换标签页

### DIFF
--- a/src/pages/Main/components/GroupList/index.tsx
+++ b/src/pages/Main/components/GroupList/index.tsx
@@ -54,6 +54,28 @@ const GroupList = () => {
     rootState.group = presetGroups[nextIndex].id;
   });
 
+  useKeyPress(["leftarrow", "rightarrow"], (event) => {
+    const active = document.activeElement;
+    if (
+      active?.tagName === "INPUT" &&
+      (active as HTMLInputElement).value !== ""
+    )
+      return;
+
+    const index = presetGroups.findIndex((item) => item.id === rootState.group);
+    const length = presetGroups.length;
+    const nextIndex =
+      event.key === "ArrowLeft"
+        ? index === 0
+          ? length - 1
+          : index - 1
+        : index === length - 1
+          ? 0
+          : index + 1;
+
+    rootState.group = presetGroups[nextIndex].id;
+  });
+
   return (
     <Scrollbar className="flex" data-tauri-drag-region>
       {presetGroups.map((item) => {


### PR DESCRIPTION
## 修改内容

搜索框为空时，按左右方向键可以循环切换标签页（All → Text → Image → File → Favorite → All）。

## 缘由
自带的shift Tab/Tab在我的Mac上不能正常切换tag
目前键盘切换标签页需要使用 Shift+Tab 组合键，操作路径较长。
方向键更直观，尤其对于频繁在 All 和 Favorite 之间切换的用户体验更好。

## 行为说明

- 搜索框**为空**时：左右键切换标签页（支持循环）
- 搜索框**有内容**时：左右键正常移动光标，不受影响
- 与现有快捷键无冲突