### PR TITLE
fix: correct timezone offset for legacy data import

### DIFF
--- a/src-tauri/src/commands/onboarding.rs
+++ b/src-tauri/src/commands/onboarding.rs
@@ -2,7 +2,7 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 use anyhow::Context;
-use chrono::{DateTime, NaiveDateTime, Utc};
+use chrono::{DateTime, Local, NaiveDateTime, TimeZone, Utc};
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use sqlx::sqlite::{SqliteConnectOptions, SqlitePoolOptions};
@@ -832,7 +832,8 @@ fn parse_legacy_datetime(value: Option<&str>) -> Option<DateTime<Utc>> {
 
     NaiveDateTime::parse_from_str(raw, "%Y-%m-%d %H:%M:%S")
         .ok()
-        .map(|time| DateTime::<Utc>::from_naive_utc_and_offset(time, Utc))
+        .and_then(|naive| Local.from_local_datetime(&naive).earliest())
+        .map(|local| local.with_timezone(&Utc))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
### Description
This PR fixes a timezone offset bug that occurred when importing legacy clipboard data. 

Previously, `parse_legacy_datetime` treated the parsed naive datetime strings as UTC. Since the legacy database stored timestamps in the user's local time (e.g., `YYYY-MM-DD HH:MM:SS` without offset information), this caused an incorrect time shift after importing.

### Changes
1. Parse the imported naive timestamp as *Local* time.
2. Convert the parsed local time to UTC for database storage.
* Imported `TimeZone` and `Local` from the `chrono` crate.

### Testing Notes
* This has been tested in **UTC+8** timezone and the imported timestamps are correct.
* *Note: This has not been verified in other time zones.*

### Related Issue
Fixes #1337 