### PR TITLE
fix: prevent app freezes that may cause history loss

### DIFF
--- a/src-tauri/src/db/init.rs
+++ b/src-tauri/src/db/init.rs
@@ -1,5 +1,7 @@
 use anyhow::Context;
+use log::LevelFilter;
 use sqlx::sqlite::{SqliteConnectOptions, SqliteJournalMode, SqlitePoolOptions, SqliteSynchronous};
+use sqlx::ConnectOptions;
 use sqlx::SqlitePool;
 use tauri::AppHandle;
 
@@ -14,7 +16,9 @@ pub async fn init(app: &AppHandle) -> Result<SqlitePool> {
         .create_if_missing(true)
         .journal_mode(SqliteJournalMode::Wal)
         .synchronous(SqliteSynchronous::Normal)
-        .foreign_keys(true);
+        .foreign_keys(true)
+        .log_statements(LevelFilter::Off)
+        .log_slow_statements(LevelFilter::Off, std::time::Duration::from_secs(1));
 
     let pool = SqlitePoolOptions::new()
         .connect_with(options)

--- a/src-tauri/src/db/init.rs
+++ b/src-tauri/src/db/init.rs
@@ -1,5 +1,4 @@
 use anyhow::Context;
-use log::LevelFilter;
 use sqlx::sqlite::{SqliteConnectOptions, SqliteJournalMode, SqlitePoolOptions, SqliteSynchronous};
 use sqlx::ConnectOptions;
 use sqlx::SqlitePool;
@@ -17,8 +16,7 @@ pub async fn init(app: &AppHandle) -> Result<SqlitePool> {
         .journal_mode(SqliteJournalMode::Wal)
         .synchronous(SqliteSynchronous::Normal)
         .foreign_keys(true)
-        .log_statements(LevelFilter::Off)
-        .log_slow_statements(LevelFilter::Off, std::time::Duration::from_secs(1));
+        .disable_statement_logging();
 
     let pool = SqlitePoolOptions::new()
         .connect_with(options)

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -26,14 +26,14 @@ pub fn run() {
     admin::handle_startup_auto_elevation();
 
     // Webview target 把日志回灌到前端 devtools console，只在 dev 启用；
-    // 生产环境只落 LogDir 文件 + Stdout，避免向用户的 webview console 喷日志。
-    let mut log_targets = vec![
-        tauri_plugin_log::Target::new(tauri_plugin_log::TargetKind::LogDir { file_name: None }),
-    ];
-    #[cfg(any(debug_assertions, not(target_os = "windows")))]
-    log_targets.push(tauri_plugin_log::Target::new(tauri_plugin_log::TargetKind::Stdout));
-
+    // 生产环境只落 LogDir 文件；Stdout 仅在 debug 启用，避免 Windows Release stdout 缓冲区阻塞，也避免向用户的 webview console 喷日志。
+    let mut log_targets = vec![tauri_plugin_log::Target::new(
+        tauri_plugin_log::TargetKind::LogDir { file_name: None },
+    )];
     if cfg!(debug_assertions) {
+        log_targets.push(tauri_plugin_log::Target::new(
+            tauri_plugin_log::TargetKind::Stdout,
+        ));
         log_targets.push(tauri_plugin_log::Target::new(
             tauri_plugin_log::TargetKind::Webview,
         ));

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -28,9 +28,11 @@ pub fn run() {
     // Webview target 把日志回灌到前端 devtools console，只在 dev 启用；
     // 生产环境只落 LogDir 文件 + Stdout，避免向用户的 webview console 喷日志。
     let mut log_targets = vec![
-        tauri_plugin_log::Target::new(tauri_plugin_log::TargetKind::Stdout),
         tauri_plugin_log::Target::new(tauri_plugin_log::TargetKind::LogDir { file_name: None }),
     ];
+    #[cfg(any(debug_assertions, not(target_os = "windows")))]
+    log_targets.push(tauri_plugin_log::Target::new(tauri_plugin_log::TargetKind::Stdout));
+
     if cfg!(debug_assertions) {
         log_targets.push(tauri_plugin_log::Target::new(
             tauri_plugin_log::TargetKind::Webview,


### PR DESCRIPTION
非常感谢开发者一直以来对这个剪切板工具的持续更新，我个人非常依赖它来提升日常工作流的效率。最近遇到了比较严重的问题，想贡献下修复方案。

之前在 Windows 上日常使用时，偶尔会遇到应用突然卡死、崩溃的问题。
因为重启就好了所以就没管。
但是最近有极大概率会直接写坏数据库，重启莫名其妙所有记录都消失了，甚至今天只是正常重启了一下电脑。
出故障的是0.5.0，但是好像1.0还是有bug。


<img width="962" height="656" alt="image" src="https://github.com/user-attachments/assets/3d11684a-71f8-470c-8a04-bae06b6c8209" />

<img width="376" height="637" alt="927121162450448875" src="https://github.com/user-attachments/assets/dd9538db-042a-4804-8517-490da2a023fb" />



## 排查

1. 虽然Release版本运行在 GUI 子系统中，但是，如果程序仍然不断向标准输出（`stdout`）写入数据，由于没有任何控制台“消费”这些输出，底层输出缓冲区很快就会被完全塞满。
   
2. `sqlx` 库默认会在 `INFO` 级别打印执行的每一条 SQL 语句，用户正常使用时产生了海量的无用日志。

3. 一旦 Windows 的 `stdout` 缓冲区被填满，任何尝试打印日志的线程都会被操作系统**永久阻塞**。
   然后又因为打印 SQL 日志被系统挂起，整个应用界面就会直接卡死。此时，如果用户强制结束这个无响应的进程（或者在此期间关机/重启电脑），SQLite 就会在极其不安全的状态下被强行杀掉，导致数据库文件和 WAL 文件状态脱节，最终造成不可逆的数据库损坏。

## 修复方案

1. **全局禁用 `sqlx` 查询日志**：从源头切断海量的 I/O 日志刷屏。
2. **在 Windows Release 下移除 `stdout` 日志目标**：通过 `#[cfg(all(not(debug_assertions), target_os = "windows"))]` 条件编译，确保即使有其他日志生成，也只会写入文件，而不会再触发系统级的 stdout 缓冲区阻塞。

由此可以保护用户的本地数据完整性，期待测试与合并，再次感谢您的开发与付出！