### PR TITLE
fix: broaden email local-part regex to include . _ + - %

### DIFF
--- a/src-tauri/src/clipboard/detect.rs
+++ b/src-tauri/src/clipboard/detect.rs
@@ -16,9 +16,9 @@ static URL_RE: LazyLock<Regex> = LazyLock::new(|| {
         .expect("invalid URL regex")
 });
 
-/// Email：允许中文用户名。
+/// Email：本地部分允许字母、数字、中文及 `.` `+` `_` `-` `%`（RFC 5321 常见字符）。
 static EMAIL_RE: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(r"^[A-Za-z0-9\u{4e00}-\u{9fa5}]+@[a-zA-Z0-9_-]+(\.[a-zA-Z0-9_-]+)+$")
+    Regex::new(r"^[A-Za-z0-9._%+\-\u{4e00}-\u{9fa5}]+@[a-zA-Z0-9_-]+(\.[a-zA-Z0-9_-]+)+$")
         .expect("invalid email regex")
 });
 
@@ -169,6 +169,32 @@ mod tests {
         assert_eq!(
             detect_text_sub_kind("张三@example.com.cn"),
             Some(ClipboardSubKind::Email)
+        );
+        // 常见但此前被 EMAIL_RE 漏判的本地部分：含 . + _ - %
+        assert_eq!(
+            detect_text_sub_kind("first.last@example.com"),
+            Some(ClipboardSubKind::Email),
+            "dotted local part (first.last@)"
+        );
+        assert_eq!(
+            detect_text_sub_kind("user+tag@gmail.com"),
+            Some(ClipboardSubKind::Email),
+            "plus-tagged local part (user+tag@)"
+        );
+        assert_eq!(
+            detect_text_sub_kind("name_surname@example.com"),
+            Some(ClipboardSubKind::Email),
+            "underscore local part (name_surname@)"
+        );
+        assert_eq!(
+            detect_text_sub_kind("user-name@example.com"),
+            Some(ClipboardSubKind::Email),
+            "hyphen local part (user-name@)"
+        );
+        assert_eq!(
+            detect_text_sub_kind("user%tag@example.com"),
+            Some(ClipboardSubKind::Email),
+            "percent local part (user%tag@)"
         );
         assert_eq!(detect_text_sub_kind("not@an@email"), None);
     }


### PR DESCRIPTION
## Summary
`detect_text_sub_kind` now classifies emails whose local part contains `.`, `_`, `+`, `-`, or `%` as `Email` instead of plain text. Addresses like `first.last@example.com`, `user+tag@gmail.com`, `name_surname@example.com`, `user-name@example.com`, `user%tag@example.com` were silently misclassified as plain text.

## Root Cause
`src-tauri/src/clipboard/detect.rs:20` — `EMAIL_RE`'s local-part class was `[A-Za-z0-9\u{4e00}-\u{9fa5}]+` (alphanumeric + CJK only), dropping the RFC 5321-common characters `.`, `+`, `_`, `-`, `%`. The sibling domain class `[a-zA-Z0-9_-]+` already admitted `_`/`-`, so this is an asymmetry/oversight, not an intentional restriction.

## Changes
- `src-tauri/src/clipboard/detect.rs`: broaden the local-part class to `[A-Za-z0-9._%+\-\u{4e00}-\u{9fa5}]+`.
- 5 regression tests in the same file's `mod tests` (dotted, plus-tagged, underscore, hyphen, percent local parts).

## Test plan
- `cd src-tauri && cargo fmt --all --check` — clean
- `cargo clippy --all-targets --all-features -- -D warnings` — clean
- `cargo test --all-targets --all-features` — the 5 new cases pass (red before the regex change, green after)
- Rust 1.96.0 per `rust-toolchain.toml`. Backend-only change — no frontend path touched, so `pnpm lint`/`pnpm tsc` are not triggered by this diff.