### PR TITLE
fix: fall back to LIKE for search keywords with short tokens

### DIFF
--- a/src-tauri/src/db/items.rs
+++ b/src-tauri/src/db/items.rs
@@ -406,12 +406,21 @@ enum KeywordFilter {
 impl KeywordFilter {
     /// 按字符数（非字节）判定走 FTS 还是 LIKE。CJK 一个字符也算 1，
     /// 与 trigram 的 3 字符门槛保持一致。
+    ///
+    /// 注意：门槛按**每个空白分词**判定，而非整串字符数。trigram 索引对 <3 字符的
+    /// token 永远 0 命中，而 FTS5 表达式里多 token 之间默认是 AND —— 只要有一个短词，
+    /// 整条表达式就被拖成 0 结果（例如 `a b` 会生成 `"a"* "b"*`，二者皆 <3 字符）。
+    /// 因此仅当所有分词均 ≥3 字符时才走 FTS，否则降级到 LIKE 兜底。
     fn from_keyword(keyword: Option<&str>) -> Self {
         let Some(trimmed) = keyword.map(str::trim).filter(|s| !s.is_empty()) else {
             return Self::None;
         };
 
-        if trimmed.chars().count() >= 3 {
+        let fts_viable = trimmed
+            .split_whitespace()
+            .all(|token| token.chars().count() >= 3);
+
+        if fts_viable {
             if let Some(expr) = build_fts_expr(trimmed) {
                 return Self::Fts(expr);
             }
@@ -1247,6 +1256,50 @@ mod tests {
             KeywordFilter::from_keyword(Some("a\"b")),
             KeywordFilter::Fts("\"a\"\"b\"*".to_owned())
         );
+    }
+
+    #[test]
+    fn keyword_filter_drops_multi_token_short_words_to_like() {
+        // 整串 ≥3 字符，但每个空白分词都 <3 字符：trigram 对 <3 字符 token 永远 0 命中，
+        // 且 FTS5 多 token 默认 AND，整条表达式会被任一短词拖成 0 结果 → 必须降级 LIKE。
+        assert_eq!(
+            KeywordFilter::from_keyword(Some("a b")),
+            KeywordFilter::Like("a b".to_owned())
+        );
+        assert_eq!(
+            KeywordFilter::from_keyword(Some("ab cd")),
+            KeywordFilter::Like("ab cd".to_owned())
+        );
+        // 混合长度：只要有一个分词 <3 字符，整条 FTS 表达式就会被拖成 0 命中 → LIKE。
+        assert_eq!(
+            KeywordFilter::from_keyword(Some("foo b")),
+            KeywordFilter::Like("foo b".to_owned())
+        );
+        // 所有分词均 ≥3 字符仍走 FTS（回归保障，语义不变）。
+        assert_eq!(
+            KeywordFilter::from_keyword(Some("foo bar baz")),
+            KeywordFilter::Fts("\"foo\"* \"bar\"* \"baz\"*".to_owned())
+        );
+    }
+
+    #[tokio::test]
+    async fn multi_token_short_keyword_falls_back_to_like() {
+        let pool = memory_pool().await;
+        let mut item = sample_item("short");
+        item.content = "ab cd ef".to_owned();
+        item.content_hash = content_hash(ClipboardKind::Text, &item.content);
+        item.search_text = Some("ab cd ef".to_owned());
+        insert_item(&pool, &item).await.unwrap();
+
+        let q = ClipboardItemQuery {
+            keyword: Some("ab cd".to_owned()),
+            ..Default::default()
+        };
+
+        // 旧逻辑按整串字符数（5 ≥ 3）判走 FTS：`"ab"* "cd"*`，两个 token 均 <3 字符，
+        // trigram 返回 0 行 → 搜不到刚插入的记录。现按分词长度降级 LIKE `%ab cd%`，命中。
+        let found = query_items(&pool, &q).await.unwrap();
+        assert_eq!(ids(&found), ["short"]);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Clipboard history search now falls back to `LIKE` when the keyword contains any whitespace-separated token shorter than 3 characters, instead of returning zero results.

## Root Cause

`KeywordFilter::from_keyword` in `src-tauri/src/db/items.rs` routed a keyword to the FTS5 trigram index whenever the **whole trimmed string** was ≥ 3 characters. For a multi-word query, `build_fts_expr` emits an AND of per-token prefix expressions (e.g. `a b` → `"a"* "b"*`).

The trigram tokenizer cannot satisfy a prefix query shorter than 3 characters and returns 0 rows for it. Because FTS5 ANDs the tokens, a single short token drags the **entire** query to 0 results — so searching e.g. `a b`, `ab cd`, or `foo b` matched nothing, even when matching items existed.

The module comment already states the intent ("1–2 字符词永远 0 命中，走 LIKE 兜底"), but the gate checked the whole-string length rather than per-token length, so the invariant was violated for multi-token keywords.

## Changes

- `src-tauri/src/db/items.rs`: `KeywordFilter::from_keyword` now routes to FTS only when **every** whitespace-split token is ≥ 3 chars; otherwise it falls through to the existing `LIKE` fallback. Single-token behavior is unchanged (`abc` → FTS, `ab` → LIKE).
- Added unit tests for the new classification (`a b`, `ab cd`, `foo b` → `Like`; `foo bar baz` → `Fts`) and an in-memory DB regression test that inserts an item with `search_text = "ab cd ef"` and asserts a `ab cd` search now finds it.

## Test plan

Verified on macOS with the pinned 1.96.0 toolchain:

```sh
cd src-tauri
cargo fmt --all --check
cargo clippy --all-targets --all-features -- -D warnings
cargo test --all-features --lib db::items::
```

All 29 `db::items::` tests pass, including the two new ones. The bug was confirmed empirically before the fix: `SELECT count(*) FROM fts5tbl WHERE tbl MATCH '"a"* "b"*'` returns 0 under the trigram tokenizer. Pure-Rust change; CI proves it compiles and tests green on Windows too.
