### PR TITLE
feat(window): 实现轻量模式以销毁后台 WebView减少运行内存占用

### DIFF
--- a/src-tauri/src/i18n/en_us/tray.rs
+++ b/src-tauri/src/i18n/en_us/tray.rs
@@ -11,5 +11,6 @@ pub fn label(key: Key) -> &'static str {
         Key::Version => "Version",
         Key::Relaunch => "Relaunch",
         Key::Exit => "Exit",
+        Key::EnterLightweight => "Lightweight Mode",
     }
 }

--- a/src-tauri/src/i18n/keys.rs
+++ b/src-tauri/src/i18n/keys.rs
@@ -37,4 +37,6 @@ pub enum TrayKey {
     Version,
     Relaunch,
     Exit,
+    /// 立即把后台驻留的 WebView 释放（强制销毁 HiddenWarm / Dormant 窗口）。
+    EnterLightweight,
 }

--- a/src-tauri/src/i18n/zh_cn/tray.rs
+++ b/src-tauri/src/i18n/zh_cn/tray.rs
@@ -11,5 +11,6 @@ pub fn label(key: Key) -> &'static str {
         Key::Version => "版本",
         Key::Relaunch => "重启应用",
         Key::Exit => "退出应用",
+        Key::EnterLightweight => "轻量模式",
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -327,8 +327,16 @@ pub fn run() {
             }
 
             // 退出前保存所有窗口几何，兜住「调整大小后不关窗直接退出」的场景。
-            if let tauri::RunEvent::ExitRequested { .. } = event {
+            // 轻量模式下剪贴板窗口会被 destroy 释放 WebView，destroy 路径不走 close 拦截，
+            // 当最后一个可见窗口销毁时 Tauri 可能投递 ExitRequested。需区分两条路径：
+            //   - 用户主动退出（托盘菜单「退出应用」）：tray 设了 USER_EXIT_REQUESTED，放行。
+            //   - destroy 触发的无主窗口退出：prevent_exit 让应用继续驻留托盘。
+            // `app.exit(0)` 也会触发 ExitRequested，所以必须用 flag 而非无条件放行。
+            if let tauri::RunEvent::ExitRequested { api, .. } = event {
                 window::save_all_window_states(app_handle);
+                if !crate::tray::USER_EXIT_REQUESTED.load(std::sync::atomic::Ordering::SeqCst) {
+                    api.prevent_exit();
+                }
             }
         });
 }

--- a/src-tauri/src/tray/mod.rs
+++ b/src-tauri/src/tray/mod.rs
@@ -5,13 +5,15 @@
 //! - 显隐跟随 `General.tray_icon`；语言或显隐变更后由 `commands/settings.rs` 调用 [`apply`] 同步。
 
 use anyhow::Context;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Mutex;
 use tauri::image::Image;
 use tauri::menu::{Menu, MenuBuilder, MenuItem, PredefinedMenuItem};
 use tauri::path::BaseDirectory;
 use tauri::tray::TrayIconBuilder;
 #[cfg(target_os = "windows")]
 use tauri::tray::{MouseButton, MouseButtonState, TrayIconEvent};
-use tauri::{AppHandle, Manager};
+use tauri::{AppHandle, Listener, Manager};
 use tauri_plugin_opener::OpenerExt;
 
 use crate::clipboard::WatcherPause;
@@ -19,6 +21,9 @@ use crate::core::Result;
 use crate::i18n::tray as tray_i18n;
 use crate::i18n::tray::Key;
 use crate::settings::{Language, Settings};
+use crate::window::lifecycle::{
+    force_destroy_idle_windows, has_destroyable_windows, WINDOW_LIFECYCLE_EVENT,
+};
 #[cfg(target_os = "windows")]
 use crate::window::CLIPBOARD_WINDOW_LABEL;
 use crate::window::{self, PREFERENCE_WINDOW_LABEL};
@@ -28,10 +33,45 @@ const GITHUB_URL: &str = "https://github.com/EcoPasteHub/EcoPaste";
 
 const MENU_PREFERENCE: &str = "tray::preference";
 const MENU_TOGGLE_LISTEN: &str = "tray::toggle_listen";
+const MENU_INSTANT_LIGHTWEIGHT: &str = "tray::instant_lightweight";
 const MENU_OPEN_SOURCE: &str = "tray::open_source";
 const MENU_CHECK_FOR_UPDATES: &str = "tray::check_for_updates";
 const MENU_RELAUNCH: &str = "tray::relaunch";
 const MENU_EXIT: &str = "tray::exit";
+
+/// 用户主动退出标记。`app.exit(0)` 会触发 `RunEvent::ExitRequested`，
+/// 需要区分「用户主动退出」与「destroy 后无主窗口触发的退出」：前者放行，后者 prevent。
+pub static USER_EXIT_REQUESTED: AtomicBool = AtomicBool::new(false);
+
+/// 全局保存「轻量模式」菜单项引用，便于 phase 变化时直接调
+/// [`MenuItem::set_enabled`] 刷新可点性，无需 [`rebuild_menu`] 重建整张菜单。
+/// `rebuild_menu` 会替换整张菜单导致正在浏览的右键菜单被平台关闭。
+static INSTANT_LIGHTWEIGHT_ITEM: Mutex<Option<MenuItem<tauri::Wry>>> = Mutex::new(None);
+
+/// 计算「轻量模式」项当前的 enabled 状态：
+/// 轻量模式总开关启用 && 至少有一个 HiddenWarm / Dormant 窗口可被销毁。
+fn instant_lightweight_enabled(app: &AppHandle) -> bool {
+    let lightweight_enabled = app
+        .try_state::<crate::settings::SettingsStore>()
+        .map(|s| s.snapshot().clipboard.window.lightweight_mode)
+        .unwrap_or(true);
+    lightweight_enabled && has_destroyable_windows(app)
+}
+
+/// 直接刷新「轻量模式」项的 enabled 状态，不重建整张菜单。
+/// lifecycle phase 变化时调用：销毁完变灰，重新隐藏窗口后恢复可点。
+pub fn update_instant_lightweight_enabled(app: &AppHandle) {
+    let enabled = instant_lightweight_enabled(app);
+    let Ok(slot) = INSTANT_LIGHTWEIGHT_ITEM.lock() else {
+        return;
+    };
+    let Some(item) = slot.as_ref() else {
+        return;
+    };
+    if let Err(err) = item.set_enabled(enabled) {
+        log::warn!("set instant_lightweight enabled failed: {err}");
+    }
+}
 
 pub fn init(app: &AppHandle, settings: &Settings) -> Result<()> {
     let lang = settings.appearance.language;
@@ -75,6 +115,20 @@ pub fn init(app: &AppHandle, settings: &Settings) -> Result<()> {
     if let Err(err) = tray.set_visible(settings.general.tray_icon) {
         log::warn!("tray set_visible on init failed: {err}");
     }
+
+    // 订阅窗口生命周期：phase 变化会影响「轻量模式」项的可点性（有 HiddenWarm /
+    // Dormant 窗口时可点，全部 Destroyed 时变灰）。listen 回调跑在异步运行时线程，
+    // set_enabled 涉及平台 menu API，故 run_on_main_thread 派发回主线程。直接刷 item
+    // 而非 rebuild_menu，避免替换整张菜单导致正在浏览的右键菜单被平台关闭。
+    let listener_app = app.clone();
+    let _ = app.listen(WINDOW_LIFECYCLE_EVENT, move |_| {
+        let app = listener_app.clone();
+        if let Err(err) = listener_app.run_on_main_thread(move || {
+            update_instant_lightweight_enabled(&app);
+        }) {
+            log::warn!("dispatch tray menu update to main thread failed: {err}");
+        }
+    });
 
     Ok(())
 }
@@ -157,6 +211,24 @@ fn build_menu(
         None::<&str>,
     )
     .context("build toggle_listen menu item")?;
+
+    // 「轻量模式」可点条件：轻量模式启用且当前存在 HiddenWarm / Dormant 窗口。
+    // 任意条件不满足（轻量未开 / 全部 Destroyed / 全部 Visible）都变灰。
+    // phase 变化时由 lifecycle 事件订阅调 update_instant_lightweight_enabled
+    // 直接刷 set_enabled，不重建整张菜单（避免关闭正在浏览的右键菜单）。
+    let instant_lightweight_enabled = instant_lightweight_enabled(app);
+    let instant_lightweight = MenuItem::with_id(
+        app,
+        MENU_INSTANT_LIGHTWEIGHT,
+        tray_i18n::label(lang, Key::EnterLightweight),
+        instant_lightweight_enabled,
+        None::<&str>,
+    )
+    .context("build instant_lightweight menu item")?;
+    if let Ok(mut slot) = INSTANT_LIGHTWEIGHT_ITEM.lock() {
+        *slot = Some(instant_lightweight.clone());
+    }
+
     let open_source = MenuItem::with_id(
         app,
         MENU_OPEN_SOURCE,
@@ -204,6 +276,7 @@ fn build_menu(
         .items(&[
             &preference,
             &toggle_listen,
+            &instant_lightweight,
             &sep1,
             &open_source,
             &check_for_updates,
@@ -234,6 +307,12 @@ fn handle_menu_event(app: &AppHandle, id: &str) {
                 }
             }
         }
+        MENU_INSTANT_LIGHTWEIGHT => {
+            // 立即销毁所有 HiddenWarm / Dormant 窗口的 WebView。force 路径复用
+            // try_destroy_idle，含 dirty / keepalive 保护与 500ms before-destroy 宽限，
+            // 销毁完成后 lifecycle 事件订阅会自动 rebuild_menu 把此项刷成不可点。
+            force_destroy_idle_windows(app);
+        }
         MENU_OPEN_SOURCE => {
             if let Err(err) = app.opener().open_url(GITHUB_URL, None::<&str>) {
                 log::error!("tray open url failed: {err:?}");
@@ -244,8 +323,16 @@ fn handle_menu_event(app: &AppHandle, id: &str) {
                 log::error!("tray open update window failed: {err:?}");
             }
         }
-        MENU_RELAUNCH => app.restart(),
-        MENU_EXIT => app.exit(0),
+        MENU_RELAUNCH => {
+            // restart 内部也会触发 ExitRequested，需同样放行。
+            USER_EXIT_REQUESTED.store(true, Ordering::SeqCst);
+            app.restart();
+        }
+        MENU_EXIT => {
+            // 标记用户主动退出，让 lib.rs 的 ExitRequested 放行（不调 prevent_exit）。
+            USER_EXIT_REQUESTED.store(true, Ordering::SeqCst);
+            app.exit(0);
+        }
         _ => {}
     }
 }

--- a/src-tauri/src/window/lifecycle/descriptor.rs
+++ b/src-tauri/src/window/lifecycle/descriptor.rs
@@ -7,8 +7,8 @@
 use tauri::AppHandle;
 
 use super::super::{
-    build_onboarding_window, build_preference_window, build_update_window, preview,
-    CLIPBOARD_PREVIEW_WINDOW_LABEL, CLIPBOARD_WINDOW_LABEL, ONBOARDING_WINDOW_LABEL,
+    build_clipboard_window, build_onboarding_window, build_preference_window, build_update_window,
+    preview, CLIPBOARD_PREVIEW_WINDOW_LABEL, CLIPBOARD_WINDOW_LABEL, ONBOARDING_WINDOW_LABEL,
     PREFERENCE_WINDOW_LABEL, UPDATE_WINDOW_LABEL,
 };
 use crate::core::Result;
@@ -47,18 +47,20 @@ pub struct WindowDescriptor {
     pub emits_lifecycle: bool,
     /// 保留 / 销毁策略。
     pub retain_policy: RetainPolicy,
-    /// 按需重建函数。`DestroyWhenIdle` 窗口被销毁后由各自打开入口用它重新建窗；
-    /// `Permanent` 窗口无需重建，为 `None`。
+    /// 按需重建函数。窗口被销毁后由各自打开入口（如 [`super::super::show_window`]）
+    /// 用它重新建窗；`Permanent` 窗口也可提供 build 以支持轻量模式下的销毁重建。
     pub build: Option<fn(&AppHandle) -> Result<()>>,
 }
 
 /// 全部窗口的静态声明表。新增窗口在此追加。
 static DESCRIPTORS: &[WindowDescriptor] = &[
+    // 剪贴板窗口：默认保留实例（`Permanent`），但轻量模式下进入 dormant 后仍会按
+    // `idle_destroy_seconds` 销毁 WebView 释放资源，故也提供 build 供 show_window 重建。
     WindowDescriptor {
         label: CLIPBOARD_WINDOW_LABEL,
         emits_lifecycle: true,
         retain_policy: RetainPolicy::Permanent,
-        build: None,
+        build: Some(build_clipboard_window),
     },
     WindowDescriptor {
         label: PREFERENCE_WINDOW_LABEL,

--- a/src-tauri/src/window/lifecycle/mod.rs
+++ b/src-tauri/src/window/lifecycle/mod.rs
@@ -149,8 +149,8 @@ impl RuntimeState {
 }
 
 /// 生命周期事件名。与 `window://visibility` 并存：visibility 只表达布尔可见性，
-/// lifecycle 表达完整阶段。
-const WINDOW_LIFECYCLE_EVENT: &str = "window://lifecycle";
+/// lifecycle 表达完整阶段。供托盘等模块订阅以联动刷新菜单。
+pub const WINDOW_LIFECYCLE_EVENT: &str = "window://lifecycle";
 const WINDOW_BEFORE_DESTROY_EVENT: &str = "window://before-destroy";
 
 #[derive(Clone, serde::Serialize)]
@@ -407,6 +407,61 @@ pub fn release_keepalive(app: &AppHandle, label: &str, owner: &str) {
     }
 }
 
+/// 当前是否存在可被「立即轻量」销毁的窗口：处于 HiddenWarm 或 Dormant 的窗口。
+/// 既没有可见 WebView、又没有挂起的空闲销毁计时器时返回 `false`，托盘据此把菜单项变灰。
+pub fn has_destroyable_windows(app: &AppHandle) -> bool {
+    let Some(manager) = manager(app) else {
+        return false;
+    };
+
+    manager.with_states(|states| {
+        states.values().any(|state| {
+            matches!(
+                state.phase,
+                LifecyclePhase::HiddenWarm | LifecyclePhase::Dormant
+            )
+        })
+    })
+}
+
+/// 立即把所有 HiddenWarm / Dormant 窗口推进销毁流水线，跳过空闲计时器等待。
+/// 复用 [`try_destroy_idle`] 路径：仍走 dirty / keepalive 检查与 500ms before-destroy
+/// 宽限，保护前端未保存的草稿。Visible 窗口不动（用户正在用），Destroyed 窗口本就无 WebView。
+/// 轻量模式未启用时整体 no-op（`try_destroy_idle` 自身会早退）。
+pub fn force_destroy_idle_windows(app: &AppHandle) {
+    let Some(manager) = manager(app) else {
+        return;
+    };
+
+    let pending: Vec<(String, u64)> = manager.with_states(|states| {
+        states
+            .iter()
+            .filter_map(|(label, state)| {
+                if matches!(
+                    state.phase,
+                    LifecyclePhase::HiddenWarm | LifecyclePhase::Dormant
+                ) {
+                    Some((label.clone(), state.generation))
+                } else {
+                    None
+                }
+            })
+            .collect()
+    });
+
+    for (label, generation) in pending {
+        // run_on_main_thread 把闭包派发回主线程执行（macOS destroy / nspanel to_window
+        // 都要求主线程）。label 会被 move 进闭包，日志侧用 clone 留一份给警告文案。
+        let log_label = label.clone();
+        let app_clone = app.clone();
+        if let Err(err) = app.run_on_main_thread(move || {
+            try_destroy_idle(&app_clone, &label, generation);
+        }) {
+            log::warn!("force destroy dispatch failed for {log_label}: {err}");
+        }
+    }
+}
+
 /// 返回所有登记窗口的生命周期调试快照。
 pub fn snapshot(app: &AppHandle) -> Vec<LifecycleSnapshot> {
     let now = Instant::now();
@@ -496,6 +551,8 @@ fn schedule_clipboard_dormant(app: &AppHandle, label: &str, generation: u64) {
 }
 
 /// 计时器到点的 dormant 判定：剪贴板窗口仍隐藏且代次未变才进入 dormant。
+/// 进入 dormant 后再启动一条空闲销毁计时器，到点释放 WebView，对齐
+/// ClashVerge 的「无 webview 后台」；非轻量模式时 [`try_destroy_idle`] 自身会早退。
 fn try_enter_dormant(app: &AppHandle, label: &str, generation: u64) {
     if !lightweight_mode_enabled(app) {
         return;
@@ -515,6 +572,12 @@ fn try_enter_dormant(app: &AppHandle, label: &str, generation: u64) {
     }
 
     manager.transition(app, label, LifecyclePhase::Dormant, "idle-dormant");
+
+    // dormant 是剪贴板窗口专属阶段：进入后再启动一条独立的空闲销毁计时器，
+    // 到点由 [`try_destroy_idle`] 走与 `DestroyWhenIdle` 窗口相同的 DestroyPending →
+    // before-destroy → finish_destroy_idle 路径释放 WebView。复用同一条销毁流水线，
+    // 不重复实现 to_window 还原 / dirty keepalive 检查 / 几何落盘等收尾。
+    schedule_idle_destroy(app, label, generation, idle_destroy_secs(app));
 }
 
 /// 启动一次性空闲销毁计时器。捕获进入隐藏态时的 `generation`，到点回主线程校验后销毁。
@@ -536,8 +599,12 @@ fn schedule_idle_destroy(app: &AppHandle, label: &str, generation: u64, timeout_
     });
 }
 
-/// 计时器到点的销毁判定（主线程）：代次未变且仍处于 HiddenWarm 才进入 DestroyPending，
-/// 否则说明窗口已被重新显示或已销毁，放弃本次销毁。
+/// 计时器到点的销毁判定（主线程）：代次未变且仍处于 HiddenWarm 或 Dormant 才进入
+/// DestroyPending，否则说明窗口已被重新显示或已销毁，放弃本次销毁。
+///
+/// `DestroyWhenIdle` 窗口（preference / preview / context menu 等）隐藏后停留在
+/// `HiddenWarm`；剪贴板窗口隐藏后先进入 `Dormant` 再由 [`try_enter_dormant`] 启动
+/// 本计时器，故同时接受 `Dormant`。两类窗口到点都汇入同一销毁流水线。
 fn try_destroy_idle(app: &AppHandle, label: &str, generation: u64) {
     if !lightweight_mode_enabled(app) {
         return;
@@ -549,7 +616,12 @@ fn try_destroy_idle(app: &AppHandle, label: &str, generation: u64) {
 
     let check = manager.with_states(|states| match states.get_mut(label) {
         Some(state) => {
-            if state.generation != generation || state.phase != LifecyclePhase::HiddenWarm {
+            if state.generation != generation
+                || !matches!(
+                    state.phase,
+                    LifecyclePhase::HiddenWarm | LifecyclePhase::Dormant
+                )
+            {
                 return DestroyCheck::Stale;
             }
 

--- a/src-tauri/src/window/macos.rs
+++ b/src-tauri/src/window/macos.rs
@@ -35,13 +35,21 @@ pub fn register_plugin(app_handle: &AppHandle) {
     let _ = app_handle.plugin(tauri_nspanel::init());
 }
 
-/// setup 末尾调用：转 NSPanel + 绑事件 emit。
+/// setup 末尾调用：dock 显隐初始化 + 转剪贴板窗口为 NSPanel 并绑事件。
 pub fn setup_clipboard_panel(app_handle: &AppHandle) -> Result<()> {
     show_taskbar_icon(app_handle, false)?;
 
     let clipboard_window = get_window(app_handle, CLIPBOARD_WINDOW_LABEL)?;
+    attach_clipboard_panel(app_handle, &clipboard_window)
+}
 
-    let panel = clipboard_window
+/// 把给定窗口转成 NSPanel 并绑 resign-key 自动隐藏事件。
+///
+/// setup 与轻量模式销毁重建均走此函数：to_panel + 圆角 / 层级 / 行为配置 + 事件绑定，
+/// 不触碰 dock 显隐等应用级状态。重复对已 to_panel 的窗口调用由 nspanel 内部判定，
+/// 重建场景下窗口是全新建出的，必然走转换分支。
+pub fn attach_clipboard_panel(app_handle: &AppHandle, window: &tauri::WebviewWindow) -> Result<()> {
+    let panel = window
         .to_panel::<MainPanel>()
         .map_err(|e| anyhow::anyhow!("to_panel failed: {e:?}"))?;
 

--- a/src-tauri/src/window/mod.rs
+++ b/src-tauri/src/window/mod.rs
@@ -262,6 +262,60 @@ pub fn intercept_close_request(window: &Window) -> bool {
     true
 }
 
+/// 按需重建剪贴板窗口。轻量模式下剪贴板窗口进入 dormant 后会按空闲秒数销毁 WebView
+/// 释放资源（对齐 ClashVerge 的"无 webview 后台"），打开时经此函数重建。
+///
+/// 选项需完整复刻 `tauri.conf.json` 中预创建的剪贴板窗口声明，否则重建后行为漂移。
+/// macOS 上还需把新建窗口转回 NSPanel（`attach_clipboard_panel`），否则平台 show 流程
+/// 取不到 panel。
+///
+/// 建窗后保持 `visible: false`：由 [`show_window`] 统一走恢复几何 + 平台 show 流程，
+/// 与其它窗口的显示路径一致。
+pub fn build_clipboard_window(app_handle: &AppHandle) -> Result<()> {
+    if app_handle
+        .get_webview_window(CLIPBOARD_WINDOW_LABEL)
+        .is_some()
+    {
+        return Ok(());
+    }
+
+    let builder = WebviewWindowBuilder::new(
+        app_handle,
+        CLIPBOARD_WINDOW_LABEL,
+        WebviewUrl::App("index.html/#/".into()),
+    )
+    .title("EcoPaste")
+    .inner_size(360.0, 600.0)
+    .min_inner_size(360.0, 600.0)
+    .maximizable(false)
+    .decorations(false)
+    .transparent(true)
+    .always_on_top(true)
+    .skip_taskbar(true)
+    .accept_first_mouse(true)
+    .focusable(false)
+    .disable_drag_drop_handler()
+    .visible(false);
+
+    builder
+        .build()
+        .map_err(|err| anyhow::anyhow!("build clipboard window: {err}"))?;
+
+    // macOS：转 NSPanel + 绑 resign-key 事件，与 setup 阶段首次建窗走相同路径。
+    // 已 to_panel 的窗口重复调用会被 nspanel 视作幂等，重建场景下窗口是新建的，必走转换。
+    #[cfg(target_os = "macos")]
+    {
+        use tauri::Manager;
+        if let Some(window) = app_handle.get_webview_window(CLIPBOARD_WINDOW_LABEL) {
+            if let Err(err) = macos::attach_clipboard_panel(app_handle, &window) {
+                log::error!("attach clipboard panel on rebuild failed: {err:?}");
+            }
+        }
+    }
+
+    Ok(())
+}
+
 /// 按需重建 preference 窗口。preference 不再由 Tauri 配置预创建（改为 `DestroyWhenIdle`），
 /// 故所有选项必须在此用 builder 完整复刻原 `tauri.conf.json` 声明，否则重建后行为漂移。
 ///

--- a/src/locales/en-US/preferences.json
+++ b/src/locales/en-US/preferences.json
@@ -583,11 +583,11 @@
       },
       "window": {
         "idleDestroySeconds": {
-          "description": "Release secondary WebViews such as preferences, preview, and context menus after they have been hidden for this long; they rebuild automatically next time.",
-          "title": "Secondary Window Idle Release"
+          "description": "Release WebViews (including the clipboard window after it goes dormant, plus secondary windows such as preferences, preview, and context menus) once they have been hidden for this long; they rebuild automatically next time.",
+          "title": "Window Idle Release"
         },
         "lightweightMode": {
-          "description": "Pause unnecessary refresh work after the clipboard window hides, and release secondary rendering resources after they become idle.",
+          "description": "Pause unnecessary refresh work after the clipboard window hides, then release WebViews (including the clipboard window itself) once idle to keep the app running in the background without a webview process.",
           "title": "Lightweight Mode"
         },
         "position": {

--- a/src/locales/zh-CN/preferences.json
+++ b/src/locales/zh-CN/preferences.json
@@ -583,11 +583,11 @@
       },
       "window": {
         "idleDestroySeconds": {
-          "description": "偏好设置、预览和右键菜单等非剪贴板窗口隐藏超过此时间后释放 WebView，下次使用时自动重建。",
-          "title": "非剪贴板窗口空闲释放"
+          "description": "剪贴板窗口进入休眠后，以及偏好设置、预览和右键菜单等次级窗口隐藏超过此时间后，都会释放 WebView 进程以降低内存占用，下次使用时自动重建。",
+          "title": "窗口空闲释放"
         },
         "lightweightMode": {
-          "description": "隐藏剪贴板窗口后暂停无谓刷新，非剪贴板窗口空闲后释放渲染资源。",
+          "description": "隐藏剪贴板窗口后暂停无谓刷新，并在空闲后释放包括剪贴板窗口在内的 WebView 渲染进程，实现无 webview 后台运行。",
           "title": "轻量模式"
         },
         "position": {


### PR DESCRIPTION

🎯 背景 (Background)
参考 ClashVerge 实现，EcoPaste 轻量模式原先仅进入 Dormant 状态，未释放 WebView 进程。当后台运行大量时间时，内存占用仍然较高（通常 > 100MB）。本 PR 旨在实现真正的“无 WebView 后台运行”。
🛠️ 实现方案 (Implementation)
1. 生命周期升级
扩展窗口销毁流程：HiddenWarm -> Dormant -> DestroyPending -> Destroyed * 剪贴板窗口：进入 Dormant 后启动空闲计时器（默认 60s），到点销毁 WebView。 * 次级窗口：进入 HiddenWarm 后立即启动计时器。
2. 托盘菜单增强
•	新增「轻量模式」菜单项，支持一键立即销毁后台 WebView（跳过 60s 等待）。
•	菜单状态联动：所有窗口销毁后菜单自动变灰。
3. 防退出机制
•	引入 api.prevent_exit() 拦截无主窗口导致的自动退出。
•	引入 USER_EXIT_REQUESTED AtomicBool 区分“用户主动退出”与“自动销毁”。
✅ 验证 (Verification)
☒	cargo fmt passed
☒	cargo clippy --all-targets -- -D warnings passed
☒	cargo test --lib (177 passed, 7 ignored)
☒	Manual Test: 轻量模式下销毁 WebView 后，托盘仍存在，应用正常驻留。
⚠️ 风险与权衡 (Risk & Trade-offs)
•	唤起延迟：WebView 销毁后首次唤起会有重建开销。已通过保留 HiddenWarm 阶段（5s）和提供手动销毁按钮平衡。
•	数据一致性：销毁前走 before-destroy 流程，保证前端有机会保存状态。

